### PR TITLE
Moves garbage disposal to main thread and ensures it via SafeHandles.

### DIFF
--- a/src/Window/ObjectBase.cs
+++ b/src/Window/ObjectBase.cs
@@ -79,7 +79,7 @@ namespace SFML
         ////////////////////////////////////////////////////////////
         protected void SetThis(IntPtr cPointer)
         {
-			if (!IsInvalid)
+			if (value != IntPtr.Zero && !IsInvalid)
 				throw new ArgumentException("Possible mem leak");
 			this.cPointer = cPointer;
         }

--- a/src/Window/ObjectBase.cs
+++ b/src/Window/ObjectBase.cs
@@ -9,10 +9,10 @@ namespace SFML
     /// SFML object. It's meant for internal use only
     /// </summary>
     ////////////////////////////////////////////////////////////
-    public abstract class ObjectBase : IDisposable
+	public abstract class ObjectBase : SafeHandle, IDisposable
     {
         private static System.Collections.Generic.List<ObjectBase> garbageCollectedObjects = new System.Collections.Generic.List<ObjectBase>();
-        private ObjectBaseSafeHandle objectSafeHandle;
+		private IntPtr cPointer;
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -21,8 +21,9 @@ namespace SFML
         /// <param name="cPointer">Internal pointer to the object in the C libraries</param>
         ////////////////////////////////////////////////////////////
         public ObjectBase(IntPtr cPointer)
+			: base(IntPtr.Zero, true)
         {
-            objectSafeHandle = new ObjectBaseSafeHandle(cPointer, this);
+			this.cPointer = cPointer;
         }
 
         ////////////////////////////////////////////////////////////
@@ -33,7 +34,7 @@ namespace SFML
         ////////////////////////////////////////////////////////////
         public IntPtr CPointer
         {
-            get { return objectSafeHandle.Ptr; }
+			get { return cPointer; }
         }
 
         ////////////////////////////////////////////////////////////
@@ -55,10 +56,10 @@ namespace SFML
         ////////////////////////////////////////////////////////////
         private void Dispose(bool disposing)
         {
-            if (!objectSafeHandle.IsInvalid)
+            if (!IsInvalid)
             {
                 Destroy(disposing);
-                objectSafeHandle.Ptr = IntPtr.Zero;
+				cPointer = IntPtr.Zero;
             }
         }
 
@@ -78,8 +79,37 @@ namespace SFML
         ////////////////////////////////////////////////////////////
         protected void SetThis(IntPtr cPointer)
         {
-            objectSafeHandle = new ObjectBaseSafeHandle(cPointer, this);
+			if (!IsInvalid)
+				throw new ArgumentException("Possible mem leak");
+			this.cPointer = cPointer;
         }
+
+		////////////////////////////////////////////////////////////
+		/// <summary>
+		/// Gets whether object references a C resource 
+		/// (used by SafeHandle to determine whether object is truly disposed)
+		/// </summary>
+		////////////////////////////////////////////////////////////
+		public override bool IsInvalid
+		{
+			get
+			{
+				return cPointer == IntPtr.Zero;
+			}
+		}
+
+		////////////////////////////////////////////////////////////
+		/// <summary>
+		/// Marks the C resource for disposal
+		/// </summary>
+		////////////////////////////////////////////////////////////
+		protected override bool ReleaseHandle()
+		{
+			//GC will wait here until all threads hit a safe point. Thus avoiding a deadlock.
+			lock (garbageCollectedObjects)
+				garbageCollectedObjects.Add(this);
+			return true;
+		}
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -107,39 +137,6 @@ namespace SFML
                         Console.WriteLine (e.Message + " at " + e.StackTrace);
                     }
                 }
-            }
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Safe handle class to ensure all objects are eventually disposed
-        /// </summary>
-        ////////////////////////////////////////////////////////////
-        private sealed class ObjectBaseSafeHandle : System.Runtime.InteropServices.SafeHandle
-        {
-            private ObjectBase objectBase;
-            public IntPtr Ptr;
-            public ObjectBaseSafeHandle(IntPtr ptr, ObjectBase objectBase)
-                : base(IntPtr.Zero, true)
-            {
-                this.Ptr = ptr;
-                this.objectBase = objectBase;
-            }
-
-            public override bool IsInvalid
-            {
-                get
-                {
-                    return Ptr == IntPtr.Zero;
-                }
-            }
-
-            protected override bool ReleaseHandle()
-            {
-                //GC will wait here until all threads hit a safe point. Thus avoiding a deadlock.
-                lock (garbageCollectedObjects)
-                    garbageCollectedObjects.Add(objectBase);
-                return true;
             }
         }
     }

--- a/src/Window/ObjectBase.cs
+++ b/src/Window/ObjectBase.cs
@@ -79,7 +79,7 @@ namespace SFML
         ////////////////////////////////////////////////////////////
         protected void SetThis(IntPtr cPointer)
         {
-			if (value != IntPtr.Zero && !IsInvalid)
+			if (cPointer != IntPtr.Zero && !IsInvalid)
 				throw new ArgumentException("Possible mem leak");
 			this.cPointer = cPointer;
         }

--- a/src/Window/Window.cs
+++ b/src/Window/Window.cs
@@ -346,6 +346,7 @@ namespace SFML
                 Event e;
                 while (PollEvent(out e))
                     CallEventHandler(e);
+                ObjectBase.DisposeGarbageCollectedObjects();
             }
 
             ////////////////////////////////////////////////////////////


### PR DESCRIPTION
See http://en.sfml-dev.org/forums/index.php?topic=12248.30

I considered moving the disposal to Window.Clear(), but this necessarily isn't called. Like Window.DispatchEvents() is.

Merged ObjectBase and ObjectBaseSafeHandle since last pull request.