### PR TITLE
fixed typos

### DIFF
--- a/src/Audio/Music.cs
+++ b/src/Audio/Music.cs
@@ -215,7 +215,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public Vector3f Position
             {
-                get { return sfMusic_getPosition(CPointer); ;}
+                get { return sfMusic_getPosition(CPointer); }
                 set { sfMusic_setPosition(CPointer, value); }
             }
 

--- a/src/Audio/SoundRecorder.cs
+++ b/src/Audio/SoundRecorder.cs
@@ -115,7 +115,7 @@ namespace SFML
             /// <summary>
             /// Start capturing audio data.
             ///
-            /// This virtual function may be overriden by a derived class
+            /// This virtual function may be overridden by a derived class
             /// if something has to be done every time a new capture
             /// starts. If not, this function can be ignored; the default
             /// implementation does nothing.
@@ -146,7 +146,7 @@ namespace SFML
             /// <summary>
             /// Stop capturing audio data.
             ///
-            /// This virtual function may be overriden by a derived class
+            /// This virtual function may be overridden by a derived class
             /// if something has to be done every time the capture
             /// ends. If not, this function can be ignored; the default
             /// implementation does nothing.

--- a/src/Graphics/Drawable.cs
+++ b/src/Graphics/Drawable.cs
@@ -12,12 +12,12 @@ namespace SFML
         public interface Drawable
         {
             ////////////////////////////////////////////////////////////
-            /// <summmary>
+            /// <summary>
             /// Draw the object to a render target
             ///
             /// This is a function that has to be implemented by the
             /// derived class to define how the drawable should be drawn.
-            /// </summmary>
+            /// </summary>
             /// <param name="target">Render target to draw to</param>
             /// <param name="states">Current render states</param>
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/Glyph.cs
+++ b/src/Graphics/Glyph.cs
@@ -13,7 +13,7 @@ namespace SFML
         [StructLayout(LayoutKind.Sequential)]
         public struct Glyph
         {
-            /// <summary>Offset to move horizontically to the next character</summary>
+            /// <summary>Offset to move horizontally to the next character</summary>
             public float Advance;
 
             /// <summary>Bounding rectangle of the glyph, in coordinates relative to the baseline</summary>

--- a/src/Graphics/PrimitiveType.cs
+++ b/src/Graphics/PrimitiveType.cs
@@ -10,7 +10,7 @@ namespace SFML
         /// Types of primitives that a VertexArray can render.
         ///
         /// Points and lines have no area, therefore their thickness
-        /// will always be 1 pixel, regarldess the current transform
+        /// will always be 1 pixel, regardless the current transform
         /// and view.
         /// </summary>
         ////////////////////////////////////////////////////////////

--- a/src/Graphics/RenderTarget.cs
+++ b/src/Graphics/RenderTarget.cs
@@ -60,7 +60,7 @@ namespace SFML
             /// coordinates, using the current view
             ///
             /// This function is an overload of the MapPixelToCoords
-            /// function that implicitely uses the current view.
+            /// function that implicitly uses the current view.
             /// It is equivalent to:
             /// target.MapPixelToCoords(point, target.GetView());
             /// </summary>
@@ -103,7 +103,7 @@ namespace SFML
             /// coordinates, using the current view
             ///
             /// This function is an overload of the mapCoordsToPixel
-            /// function that implicitely uses the current view.
+            /// function that implicitly uses the current view.
             /// It is equivalent to:
             /// target.MapCoordsToPixel(point, target.GetView());
             /// </summary>

--- a/src/Graphics/RenderTexture.cs
+++ b/src/Graphics/RenderTexture.cs
@@ -120,7 +120,7 @@ namespace SFML
             /// coordinates, using the current view
             ///
             /// This function is an overload of the MapPixelToCoords
-            /// function that implicitely uses the current view.
+            /// function that implicitly uses the current view.
             /// It is equivalent to:
             /// target.MapPixelToCoords(point, target.GetView());
             /// </summary>
@@ -169,7 +169,7 @@ namespace SFML
             /// coordinates, using the current view
             ///
             /// This function is an overload of the mapCoordsToPixel
-            /// function that implicitely uses the current view.
+            /// function that implicitly uses the current view.
             /// It is equivalent to:
             /// target.MapCoordsToPixel(point, target.GetView());
             /// </summary>

--- a/src/Graphics/RenderWindow.cs
+++ b/src/Graphics/RenderWindow.cs
@@ -340,7 +340,7 @@ namespace SFML
             /// coordinates, using the current view
             ///
             /// This function is an overload of the MapPixelToCoords
-            /// function that implicitely uses the current view.
+            /// function that implicitly uses the current view.
             /// It is equivalent to:
             /// target.MapPixelToCoords(point, target.GetView());
             /// </summary>
@@ -389,7 +389,7 @@ namespace SFML
             /// coordinates, using the current view
             ///
             /// This function is an overload of the mapCoordsToPixel
-            /// function that implicitely uses the current view.
+            /// function that implicitly uses the current view.
             /// It is equivalent to:
             /// target.MapCoordsToPixel(point, target.GetView());
             /// </summary>

--- a/src/Graphics/Shape.cs
+++ b/src/Graphics/Shape.cs
@@ -129,9 +129,9 @@ namespace SFML
             }
 
             ////////////////////////////////////////////////////////////
-            /// <summmary>
+            /// <summary>
             /// Draw the shape to a render target
-            /// </summmary>
+            /// </summary>
             /// <param name="target">Render target to draw to</param>
             /// <param name="states">Current render states</param>
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/Sprite.cs
+++ b/src/Graphics/Sprite.cs
@@ -155,9 +155,9 @@ namespace SFML
             }
 
             ////////////////////////////////////////////////////////////
-            /// <summmary>
+            /// <summary>
             /// Draw the sprite to a render target
-            /// </summmary>
+            /// </summary>
             /// <param name="target">Render target to draw to</param>
             /// <param name="states">Current render states</param>
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/Text.cs
+++ b/src/Graphics/Text.cs
@@ -253,9 +253,9 @@ namespace SFML
             }
 
             ////////////////////////////////////////////////////////////
-            /// <summmary>
+            /// <summary>
             /// Draw the text to a render target
-            /// </summmary>
+            /// </summary>
             /// <param name="target">Render target to draw to</param>
             /// <param name="states">Current render states</param>
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/VertexArray.cs
+++ b/src/Graphics/VertexArray.cs
@@ -150,12 +150,12 @@ namespace SFML
             }
 
             ////////////////////////////////////////////////////////////
-            /// <summmary>
+            /// <summary>
             /// Compute the bounding rectangle of the vertex array.
             ///
             /// This function returns the axis-aligned rectangle that
             /// contains all the vertices of the array.
-            /// </summmary>
+            /// </summary>
             ////////////////////////////////////////////////////////////
             public FloatRect Bounds
             {
@@ -163,9 +163,9 @@ namespace SFML
             }
 
             ////////////////////////////////////////////////////////////
-            /// <summmary>
+            /// <summary>
             /// Draw the vertex array to a render target
-            /// </summmary>
+            /// </summary>
             /// <param name="target">Render target to draw to</param>
             /// <param name="states">Current render states</param>
             ////////////////////////////////////////////////////////////

--- a/src/System/ObjectBase.cs
+++ b/src/System/ObjectBase.cs
@@ -46,7 +46,7 @@ namespace SFML
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Explicitely dispose the object
+        /// Explicitly dispose the object
         /// </summary>
         ////////////////////////////////////////////////////////////
         public void Dispose()

--- a/src/Window/ContextSettings.cs
+++ b/src/Window/ContextSettings.cs
@@ -91,7 +91,7 @@ namespace SFML
                        " AntialiasingLevel(" + AntialiasingLevel + ")" +
                        " MajorVersion(" + MajorVersion + ")" +
                        " MinorVersion(" + MinorVersion + ")" +
-                       " AttributeFlags" + AttributeFlags + ")";
+                       " AttributeFlags(" + AttributeFlags + ")";
             }
 
             /// <summary>Depth buffer bits (0 is disabled)</summary>

--- a/src/Window/Joystick.cs
+++ b/src/Window/Joystick.cs
@@ -126,7 +126,7 @@ namespace SFML
             /// Update the states of all joysticks
             /// </summary>
             /// This function is used internally by SFML, so you normally
-            /// don't have to call it explicitely. However, you may need to
+            /// don't have to call it explicitly. However, you may need to
             /// call it if you have no window yet (or no window at all):
             /// in this case the joysticks states are not updated automatically.
             ////////////////////////////////////////////////////////////
@@ -145,13 +145,13 @@ namespace SFML
             public static Identification GetIdentification(uint joystick)
             {
                 IdentificationMarshalData identification = sfJoystick_getIdentification(joystick);
-                Identification retidentification = new Identification();
+                Identification retIdentification = new Identification();
 
-                retidentification.Name      = Marshal.PtrToStringAnsi(identification.Name);
-                retidentification.VendorId  = identification.VendorId;
-                retidentification.ProductId = identification.ProductId;
+                retIdentification.Name      = Marshal.PtrToStringAnsi(identification.Name);
+                retIdentification.VendorId  = identification.VendorId;
+                retIdentification.ProductId = identification.ProductId;
 
-                return retidentification;
+                return retIdentification;
             }
 
             ////////////////////////////////////////////////////////////

--- a/src/Window/StreamAdaptor.cs
+++ b/src/Window/StreamAdaptor.cs
@@ -127,7 +127,7 @@ namespace SFML
 
             ////////////////////////////////////////////////////////////
             /// <summary>
-            /// Explicitely dispose the object
+            /// Explicitly dispose the object
             /// </summary>
             ////////////////////////////////////////////////////////////
             public void Dispose()


### PR DESCRIPTION
Almost ashamed to make a PR for this.

- Added a missing bracket to ContextSettings.ToString()
- Removed an empty ; in Music
- fixed some typos in the comments / xml
