### PR TITLE
Updated Glyph bounds to Int.

### DIFF
--- a/src/Graphics/Glyph.cs
+++ b/src/Graphics/Glyph.cs
@@ -17,7 +17,7 @@ namespace SFML
             public float Advance;
 
             /// <summary>Bounding rectangle of the glyph, in coordinates relative to the baseline</summary>
-            public FloatRect Bounds;
+            public IntRect Bounds;
 
             /// <summary>Texture coordinates of the glyph inside the font's texture</summary>
             public IntRect TextureRect;


### PR DESCRIPTION
Updated the bounds of Glyph to IntRect instead of FloatRect, as it in the C++ version is an IntRect and not a FloatRect.
See: http://www.sfml-dev.org/documentation/2.0/classsf_1_1Glyph.php#afe4cd37e5839955d7dd008e178d41f0c