### PR TITLE
Fixed incorrect logic in Color multiplication operator.

### DIFF
--- a/src/Graphics/Color.cs
+++ b/src/Graphics/Color.cs
@@ -196,10 +196,10 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public static Color operator *(Color left, Color right)
             {
-                return new Color((byte)Math.Min(left.R * right.R, 255),
-                                 (byte)Math.Min(left.G * right.G, 255),
-                                 (byte)Math.Min(left.B * right.B, 255),
-                                 (byte)Math.Min(left.A * right.A, 255));
+                return new Color((byte)((int)left.R * right.R / 255),
+                                 (byte)((int)left.G * right.G / 255),
+                                 (byte)((int)left.B * right.B / 255),
+                                 (byte)((int)left.A * right.A / 255));
             }
 
             /// <summary>Red component of the color</summary>


### PR DESCRIPTION
The multiplication operator was incorrect.
I made the change based on the SFML C++ implementation of the multiplication operator.