### PR TITLE
Add missing Context.Settings property, ContextSettings.SRgbCapable field, and Keyboard.SetVirtualKeyboardVisible() function

### DIFF
--- a/doc/build/sfmlnet-window-2.xml
+++ b/doc/build/sfmlnet-window-2.xml
@@ -24,6 +24,18 @@
             Activate or deactivate the context
             </summary>
             <param name="active">True to activate, false to deactivate</param>
+            <returns>true on success, false on failure</returns>
+        </member>
+        <member name="M:SFML.Window.Context.GetSettings">
+            <summary>
+            Get the settings of the context.
+            </summary>
+            <returns>Structure containing the settings</returns>
+            <remarks>
+            Note that these settings may be different than the ones passed to the
+            constructor; they are indeed adjusted if the original settings are not
+            directly supported by the system.
+            </remarks>
         </member>
         <member name="P:SFML.Window.Context.Global">
             <summary>

--- a/src/Graphics/RenderWindow.cs
+++ b/src/Graphics/RenderWindow.cs
@@ -661,10 +661,10 @@ namespace SFML.Graphics
         /// Deprecated. Use <see cref="Texture"/> and <see cref="Texture.Update(RenderWindow)"/>
         /// instead:
         /// <code>
-        ///	Texture texture = new Texture(window.Size);
-        ///	texture.update(window);
-        ///	Image img = texture.CopyToImage();
-        ///	</code>
+        ///    Texture texture = new Texture(window.Size);
+        ///    texture.update(window);
+        ///    Image img = texture.CopyToImage();
+        ///    </code>
         /// </remarks>
         ////////////////////////////////////////////////////////////
         [Obsolete("Capture is deprecated, please see remarks for preferred method")]

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -6,5 +6,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(true)]
 
-[assembly: AssemblyVersion("2.3.0")]
-[assembly: AssemblyFileVersion("2.3.0")]
+[assembly: AssemblyVersion("2.4.0")]
+[assembly: AssemblyFileVersion("2.4.0")]

--- a/src/Window/Context.cs
+++ b/src/Window/Context.cs
@@ -37,20 +37,22 @@ namespace SFML.Window
         /// Activate or deactivate the context
         /// </summary>
         /// <param name="active">True to activate, false to deactivate</param>
-		/// <returns>true on success, false on failure</returns>
+        /// <returns>true on success, false on failure</returns>
         ////////////////////////////////////////////////////////////
         public bool SetActive(bool active)
         {
             return sfContext_setActive(myThis, active);
         }
 
-		/// <summary>
-		/// Get the settings of the context.
-		/// </summary>
-		public ContextSettings Settings
-		{
-			get { return sfContext_getSettings(myThis); }
-		}
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Get the settings of the context.
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public ContextSettings Settings
+        {
+            get { return sfContext_getSettings(myThis); }
+        }
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -93,8 +95,8 @@ namespace SFML.Window
         [DllImport("csfml-window-2", CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern bool sfContext_setActive(IntPtr View, bool Active);
 
-		[DllImport("csfml-window-2", CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-		static extern ContextSettings sfContext_getSettings(IntPtr View);
-		#endregion
-	}
+        [DllImport("csfml-window-2", CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern ContextSettings sfContext_getSettings(IntPtr View);
+        #endregion
+    }
 }

--- a/src/Window/Context.cs
+++ b/src/Window/Context.cs
@@ -37,11 +37,20 @@ namespace SFML.Window
         /// Activate or deactivate the context
         /// </summary>
         /// <param name="active">True to activate, false to deactivate</param>
+		/// <returns>true on success, false on failure</returns>
         ////////////////////////////////////////////////////////////
-        public void SetActive(bool active)
+        public bool SetActive(bool active)
         {
-            sfContext_setActive(myThis, active);
+            return sfContext_setActive(myThis, active);
         }
+
+		/// <summary>
+		/// Get the settings of the context.
+		/// </summary>
+		public ContextSettings Settings
+		{
+			get { return sfContext_getSettings(myThis); }
+		}
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -82,7 +91,10 @@ namespace SFML.Window
         static extern void sfContext_destroy(IntPtr View);
 
         [DllImport("csfml-window-2", CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfContext_setActive(IntPtr View, bool Active);
-        #endregion
-    }
+        static extern bool sfContext_setActive(IntPtr View, bool Active);
+
+		[DllImport("csfml-window-2", CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+		static extern ContextSettings sfContext_getSettings(IntPtr View);
+		#endregion
+	}
 }

--- a/src/Window/ContextSettings.cs
+++ b/src/Window/ContextSettings.cs
@@ -64,7 +64,7 @@ namespace SFML.Window
         /// <param name="majorVersion">Major number of the context version</param>
         /// <param name="minorVersion">Minor number of the context version</param>
         /// <param name="attributes">Attribute flags of the context</param>
-		/// <param name="sRgbCapable">sRGB capability of the context</param>
+        /// <param name="sRgbCapable">sRGB capability of the context</param>
         ////////////////////////////////////////////////////////////
         public ContextSettings(uint depthBits, uint stencilBits, uint antialiasingLevel, uint majorVersion, uint minorVersion, Attribute attributes, bool sRgbCapable)
         {
@@ -74,8 +74,8 @@ namespace SFML.Window
             MajorVersion = majorVersion;
             MinorVersion = minorVersion;
             AttributeFlags = attributes;
-			SRgbCapable = sRgbCapable;
-		}
+            SRgbCapable = sRgbCapable;
+        }
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -112,7 +112,7 @@ namespace SFML.Window
         /// <summary>The attribute flags to create the context with</summary>
         public Attribute AttributeFlags;
 
-		/// <summary>Whether the context framebuffer is sRGB capable</summary>
-		public bool SRgbCapable;
+        /// <summary>Whether the context framebuffer is sRGB capable</summary>
+        public bool SRgbCapable;
     }
 }

--- a/src/Window/ContextSettings.cs
+++ b/src/Window/ContextSettings.cs
@@ -50,7 +50,7 @@ namespace SFML.Window
         /// <param name="antialiasingLevel">Antialiasing level</param>
         ////////////////////////////////////////////////////////////
         public ContextSettings(uint depthBits, uint stencilBits, uint antialiasingLevel) :
-            this(depthBits, stencilBits, antialiasingLevel, 2, 0, Attribute.Default)
+            this(depthBits, stencilBits, antialiasingLevel, 2, 0, Attribute.Default, false)
         {
         }
 
@@ -64,8 +64,9 @@ namespace SFML.Window
         /// <param name="majorVersion">Major number of the context version</param>
         /// <param name="minorVersion">Minor number of the context version</param>
         /// <param name="attributes">Attribute flags of the context</param>
+		/// <param name="sRgbCapable">sRGB capability of the context</param>
         ////////////////////////////////////////////////////////////
-        public ContextSettings(uint depthBits, uint stencilBits, uint antialiasingLevel, uint majorVersion, uint minorVersion, Attribute attributes)
+        public ContextSettings(uint depthBits, uint stencilBits, uint antialiasingLevel, uint majorVersion, uint minorVersion, Attribute attributes, bool sRgbCapable)
         {
             DepthBits = depthBits;
             StencilBits = stencilBits;
@@ -73,7 +74,8 @@ namespace SFML.Window
             MajorVersion = majorVersion;
             MinorVersion = minorVersion;
             AttributeFlags = attributes;
-        }
+			SRgbCapable = sRgbCapable;
+		}
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -109,5 +111,8 @@ namespace SFML.Window
 
         /// <summary>The attribute flags to create the context with</summary>
         public Attribute AttributeFlags;
+
+		/// <summary>Whether the context framebuffer is sRGB capable</summary>
+		public bool SRgbCapable;
     }
 }

--- a/src/Window/Keyboard.cs
+++ b/src/Window/Keyboard.cs
@@ -238,9 +238,24 @@ namespace SFML.Window
             return sfKeyboard_isKeyPressed(key);
         }
 
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Enable/Disable visibility of the virtual keyboard
+        /// </summary>
+        /// <remarks>Applicable only on Android and iOS</remarks>
+        /// <param name="visible">Whether to make the virtual keyboard visible (true) or not (false)</param>
+        ////////////////////////////////////////////////////////////
+        public static void SetVirtualKeyboardVisible(bool visible)
+        {
+            sfKeyboard_setVirtualKeyboardVisible(visible);
+        }
+
         #region Imports
         [DllImport("csfml-window-2", CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern bool sfKeyboard_isKeyPressed(Key Key);
+
+        [DllImport("csfml-window-2", CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfKeyboard_setVirtualKeyboardVisible(bool visible);
         #endregion
     }
 }


### PR DESCRIPTION
Context.SetActive() now returns bool for success/failure.

Bumped SolutionInfo.cs version to 2.4.

Matching CSFML commits:
SFML/CSFML@57eda5f9234a58d45d82f74ca8e4644478cd2118
SFML/CSFML@52c7de16f0e1d2c5d97e46598161b76cff7c6f18
