### PR TITLE
Fixed addition/subtraction for Vector3f

### DIFF
--- a/src/System/Vector3.cs
+++ b/src/System/Vector3.cs
@@ -44,7 +44,7 @@ namespace SFML.System
         /// <param name="v2">Second vector</param>
         /// <returns>v1 - v2</returns>
         ////////////////////////////////////////////////////////////
-        public static Vector3f operator -(Vector3f v1, Vector3f v2) => new Vector3f(v1.X - v2.X, v1.Y - v2.X, v1.Z - v2.Z);
+        public static Vector3f operator -(Vector3f v1, Vector3f v2) => new Vector3f(v1.X - v2.X, v1.Y - v2.Y, v1.Z - v2.Z);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -54,7 +54,7 @@ namespace SFML.System
         /// <param name="v2">Second vector</param>
         /// <returns>v1 + v2</returns>
         ////////////////////////////////////////////////////////////
-        public static Vector3f operator +(Vector3f v1, Vector3f v2) => new Vector3f(v1.X + v2.X, v1.Y + v2.X, v1.Z + v2.Z);
+        public static Vector3f operator +(Vector3f v1, Vector3f v2) => new Vector3f(v1.X + v2.X, v1.Y + v2.Y, v1.Z + v2.Z);
 
         ////////////////////////////////////////////////////////////
         /// <summary>


### PR DESCRIPTION
This fixes a weird issue (obviously typos), where `Vector2f` addition/subtraction would use the wrong components of the second vector.