### PR TITLE
Update SFML.Net to 2.5.0

### DIFF
--- a/src/Audio/Music.cs
+++ b/src/Audio/Music.cs
@@ -293,6 +293,24 @@ namespace SFML.Audio
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Current loop points of the music.
+        /// 
+        /// Since setting performs some adjustments on the
+        /// provided values and rounds them to internal samples, getting this
+        /// value later is not guaranteed to return the same times passed
+        /// into it. However, it is guaranteed to return times that will map 
+        /// to the valid internal samples of this Music if they are later
+        /// set again.
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public TimeSpan LoopPoints
+        {
+            get { return sfMusic_getLoopPoints(CPointer); }
+            set { sfMusic_setLoopPoints(CPointer, value); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Provide a string describing the object
         /// </summary>
         /// <returns>String description of the object</returns>
@@ -311,7 +329,8 @@ namespace SFML.Audio
                    " RelativeToListener(" + RelativeToListener + ")" +
                    " MinDistance(" + MinDistance + ")" +
                    " Attenuation(" + Attenuation + ")" +
-                   " PlayingOffset(" + PlayingOffset + ")";
+                   " PlayingOffset(" + PlayingOffset + ")" +
+                   " LoopPoints(" + LoopPoints + ")";
         }
 
         ////////////////////////////////////////////////////////////
@@ -334,6 +353,13 @@ namespace SFML.Audio
         }
 
         private StreamAdaptor myStream = null;
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct TimeSpan
+        {
+            Time offset;
+            Time length;
+        }
 
         #region Imports
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
@@ -362,6 +388,12 @@ namespace SFML.Audio
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern Time sfMusic_getDuration(IntPtr Music);
+
+        [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern TimeSpan sfMusic_getLoopPoints(IntPtr Music);
+
+        [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern TimeSpan sfMusic_setLoopPoints(IntPtr Music, TimeSpan timePoints);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern uint sfMusic_getChannelCount(IntPtr Music);

--- a/src/Audio/sfml-audio.csproj
+++ b/src/Audio/sfml-audio.csproj
@@ -26,7 +26,7 @@
 		<IsOSX>False</IsOSX>
 		<IsAndroid>False</IsAndroid>
 		<IsLinux>False</IsLinux>
-		<Version>2.5.1</Version>
+		<Version>2.5.0</Version>
 		<Description>Audio module of the SFML library</Description>
 	</PropertyGroup>
 

--- a/src/Audio/sfml-audio.csproj
+++ b/src/Audio/sfml-audio.csproj
@@ -26,7 +26,7 @@
 		<IsOSX>False</IsOSX>
 		<IsAndroid>False</IsAndroid>
 		<IsLinux>False</IsLinux>
-		<Version>2.4.2</Version>
+		<Version>2.5.1</Version>
 		<Description>Audio module of the SFML library</Description>
 	</PropertyGroup>
 

--- a/src/Graphics/Font.cs
+++ b/src/Graphics/Font.cs
@@ -57,22 +57,7 @@ namespace SFML.Graphics
         /// <param name="bytes">Byte array containing the file contents</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Font(byte[] bytes) : base(IntPtr.Zero)
-        {
-            GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            try
-            {
-                CPointer = sfFont_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
-            }
-            finally
-            {
-                pin.Free();
-            }
-            if (CPointer == IntPtr.Zero)
-            {
-                throw new LoadingFailedException("font");
-            }
-        }
+        public Font(byte[] bytes) : this(new MemoryStream(bytes)) { }
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/Graphics/RenderTexture.cs
+++ b/src/Graphics/RenderTexture.cs
@@ -34,8 +34,27 @@ namespace SFML.Graphics
         /// <param name="height">Height of the render-texture</param>
         /// <param name="depthBuffer">Do you want a depth-buffer attached?</param>
         ////////////////////////////////////////////////////////////
+        [Obsolete("Creating a RenderTexture with depthBuffer is deprecated.  Use RenderTexture(width, height, contextSettings) instead.")]
         public RenderTexture(uint width, uint height, bool depthBuffer) :
             base(sfRenderTexture_create(width, height, depthBuffer))
+        {
+            myDefaultView = new View(sfRenderTexture_getDefaultView(CPointer));
+            myTexture = new Texture(sfRenderTexture_getTexture(CPointer));
+            GC.SuppressFinalize(myDefaultView);
+            GC.SuppressFinalize(myTexture);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Create the render-texture with the given dimensions and
+        /// a ContextSettings.
+        /// </summary>
+        /// <param name="width">Width of the render-texture</param>
+        /// <param name="height">Height of the render-texture</param>
+        /// <param name="settings">A ContextSettings struct representing settings for the RenderTexture</param>
+        ////////////////////////////////////////////////////////////
+        public RenderTexture(uint width, uint height, ContextSettings contextSettings) :
+            base(sfRenderTexture_createWithSettings(width, height, contextSettings))
         {
             myDefaultView = new View(sfRenderTexture_getDefaultView(CPointer));
             myTexture = new Texture(sfRenderTexture_getTexture(CPointer));
@@ -285,6 +304,13 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// The maximum anti-aliasing level supported by the system
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        static public uint MaximumAntialiasingLevel => sfRenderTexture_getMaximumAntialiasingLevel();
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Control the smooth filter
         /// </summary>
         ////////////////////////////////////////////////////////////
@@ -499,8 +525,12 @@ namespace SFML.Graphics
         private Texture myTexture = null;
 
         #region Imports
+        [Obsolete("sfRenderTexture_create is obselete.  Use sfRenderTexture_createWithSettings instead.")]
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern IntPtr sfRenderTexture_create(uint Width, uint Height, bool DepthBuffer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern IntPtr sfRenderTexture_createWithSettings(uint Width, uint Height, ContextSettings Settings);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfRenderTexture_destroy(IntPtr CPointer);
@@ -543,6 +573,9 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern IntPtr sfRenderTexture_getTexture(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern uint sfRenderTexture_getMaximumAntialiasingLevel();
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfRenderTexture_setSmooth(IntPtr CPointer, bool smooth);

--- a/src/Graphics/RenderTexture.cs
+++ b/src/Graphics/RenderTexture.cs
@@ -34,7 +34,7 @@ namespace SFML.Graphics
         /// <param name="height">Height of the render-texture</param>
         /// <param name="depthBuffer">Do you want a depth-buffer attached?</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("Creating a RenderTexture with depthBuffer is deprecated.  Use RenderTexture(width, height, contextSettings) instead.")]
+        [Obsolete("Creating a RenderTexture with depthBuffer is deprecated. Use RenderTexture(width, height, contextSettings) instead.")]
         public RenderTexture(uint width, uint height, bool depthBuffer) :
             base(sfRenderTexture_create(width, height, depthBuffer))
         {
@@ -525,7 +525,7 @@ namespace SFML.Graphics
         private Texture myTexture = null;
 
         #region Imports
-        [Obsolete("sfRenderTexture_create is obselete.  Use sfRenderTexture_createWithSettings instead.")]
+        [Obsolete("sfRenderTexture_create is obselete. Use sfRenderTexture_createWithSettings instead.")]
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern IntPtr sfRenderTexture_create(uint Width, uint Height, bool DepthBuffer);
 

--- a/src/Graphics/RenderWindow.cs
+++ b/src/Graphics/RenderWindow.cs
@@ -732,7 +732,7 @@ namespace SFML.Graphics
         /// </summary>
         /// <returns>Relative mouse position</returns>
         ////////////////////////////////////////////////////////////
-        protected internal override Vector2i InternalGetMousePosition()
+        protected override Vector2i InternalGetMousePosition()
         {
             return sfMouse_getPositionRenderWindow(CPointer);
         }
@@ -745,7 +745,7 @@ namespace SFML.Graphics
         /// </summary>
         /// <param name="position">Relative mouse position</param>
         ////////////////////////////////////////////////////////////
-        protected internal override void InternalSetMousePosition(Vector2i position)
+        protected override void InternalSetMousePosition(Vector2i position)
         {
             sfMouse_setPositionRenderWindow(position, CPointer);
         }
@@ -759,7 +759,7 @@ namespace SFML.Graphics
         /// <param name="Finger">Finger index</param>
         /// <returns>Relative touch position</returns>
         ////////////////////////////////////////////////////////////
-        protected internal override Vector2i InternalGetTouchPosition(uint Finger)
+        protected override Vector2i InternalGetTouchPosition(uint Finger)
         {
             return sfTouch_getPositionRenderWindow(Finger, CPointer);
         }

--- a/src/Graphics/RenderWindow.cs
+++ b/src/Graphics/RenderWindow.cs
@@ -240,6 +240,17 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Set the displayed cursor to a native system cursor
+        /// </summary>
+        /// <param name="cursor">Native system cursor type to display</param>
+        ////////////////////////////////////////////////////////////
+        public override void SetMouseCursor(Cursor cursor)
+        {
+            sfRenderWindow_setMouseCursor(CPointer, cursor.CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Enable or disable automatic key-repeat.
         /// Automatic key-repeat is enabled by default
         /// </summary>
@@ -721,7 +732,7 @@ namespace SFML.Graphics
         /// </summary>
         /// <returns>Relative mouse position</returns>
         ////////////////////////////////////////////////////////////
-        protected override Vector2i InternalGetMousePosition()
+        protected internal override Vector2i InternalGetMousePosition()
         {
             return sfMouse_getPositionRenderWindow(CPointer);
         }
@@ -734,7 +745,7 @@ namespace SFML.Graphics
         /// </summary>
         /// <param name="position">Relative mouse position</param>
         ////////////////////////////////////////////////////////////
-        protected override void InternalSetMousePosition(Vector2i position)
+        protected internal override void InternalSetMousePosition(Vector2i position)
         {
             sfMouse_setPositionRenderWindow(position, CPointer);
         }
@@ -748,7 +759,7 @@ namespace SFML.Graphics
         /// <param name="Finger">Finger index</param>
         /// <returns>Relative touch position</returns>
         ////////////////////////////////////////////////////////////
-        protected override Vector2i InternalGetTouchPosition(uint Finger)
+        protected internal override Vector2i InternalGetTouchPosition(uint Finger)
         {
             return sfTouch_getPositionRenderWindow(Finger, CPointer);
         }
@@ -842,6 +853,9 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfRenderWindow_setMouseCursorGrabbed(IntPtr CPointer, bool grabbed);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfRenderWindow_setMouseCursor(IntPtr window, IntPtr cursor);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfRenderWindow_setKeyRepeatEnabled(IntPtr CPointer, bool Enable);

--- a/src/Graphics/Text.cs
+++ b/src/Graphics/Text.cs
@@ -234,6 +234,28 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Size of the letter spacing factor
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public float LetterSpacing
+        {
+            get { return sfText_getLetterSpacing(CPointer); }
+            set { sfText_setLetterSpacing(CPointer, value); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Size of the line spacing factor
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public float LineSpacing
+        {
+            get { return sfText_getLineSpacing(CPointer); }
+            set { sfText_setLineSpacing(CPointer, value); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Style of the text (see Styles enum)
         /// </summary>
         ////////////////////////////////////////////////////////////
@@ -396,6 +418,12 @@ namespace SFML.Graphics
         static extern void sfText_setCharacterSize(IntPtr CPointer, uint Size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfText_setLineSpacing(IntPtr CPointer, float spacingFactor);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfText_setLetterSpacing(IntPtr CPointer, float spacingFactor);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfText_setStyle(IntPtr CPointer, Styles Style);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
@@ -406,6 +434,12 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern uint sfText_getCharacterSize(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern float sfText_getLetterSpacing(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern float sfText_getLineSpacing(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern Styles sfText_getStyle(IntPtr CPointer);

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -221,6 +221,19 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Update a part of this texture from another texture
+        /// </summary>
+        /// <param name="texture">Source texture to copy to destination texture</param>
+        /// <param name="x">X offset in this texture where to copy the source texture</param>
+        /// <param name="y">Y offset in this texture where to copy the source texture</param>
+        ////////////////////////////////////////////////////////////
+        public void Update(Texture texture, uint x, uint y)
+        {
+            sfTexture_updateFromTexture(CPointer, texture.CPointer, x, y);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Update a texture from an image
         /// </summary>
         /// <param name="image">Image to copy to the texture</param>
@@ -320,6 +333,17 @@ namespace SFML.Graphics
         public bool GenerateMipmap()
         {
             return sfTexture_generateMipmap(CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Swap the contents of this texture with those of another
+        /// </summary>
+        /// <param name="right">Instance to swap with</param>
+        ////////////////////////////////////////////////////////////
+        public void Swap(Texture right)
+        {
+            sfTexture_swap(CPointer, right.CPointer);
         }
 
         ////////////////////////////////////////////////////////////
@@ -487,6 +511,9 @@ namespace SFML.Graphics
         unsafe static extern void sfTexture_updateFromPixels(IntPtr texture, byte* pixels, uint width, uint height, uint x, uint y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfTexture_updateFromTexture(IntPtr CPointer, IntPtr texture, uint x, uint y);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfTexture_updateFromImage(IntPtr texture, IntPtr image, uint x, uint y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
@@ -518,6 +545,9 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern bool sfTexture_generateMipmap(IntPtr texture);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfTexture_swap(IntPtr CPointer, IntPtr right);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern uint sfTexture_getNativeHandle(IntPtr shader);

--- a/src/Graphics/Transform.cs
+++ b/src/Graphics/Transform.cs
@@ -11,7 +11,7 @@ namespace SFML.Graphics
     /// </summary>
     ////////////////////////////////////////////////////////////
     [StructLayout(LayoutKind.Sequential)]
-    public struct Transform : IEquatable<Transform>
+    public struct Transform
     {
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/Graphics/Transform.cs
+++ b/src/Graphics/Transform.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
@@ -10,7 +11,7 @@ namespace SFML.Graphics
     /// </summary>
     ////////////////////////////////////////////////////////////
     [StructLayout(LayoutKind.Sequential)]
-    public struct Transform
+    public struct Transform : IEquatable<Transform>
     {
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -243,6 +244,30 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Compare Transform and object and checks if they are equal
+        /// </summary>
+        /// <param name="obj">Object to check</param>
+        /// <returns>Object and transform are equal</returns>
+        ////////////////////////////////////////////////////////////
+        public override bool Equals(object obj) => (obj is Transform) && Equals((Transform)obj);
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Compare two transforms for equality
+        ///
+        /// Performs an element-wise comparison of the elements of this
+        /// transform with the elements of the right transform.
+        /// </summary>
+        /// <param name="transform">Transform to check</param>
+        /// <returns>Transforms are equal</returns>
+        ////////////////////////////////////////////////////////////
+        public bool Equals(Transform transform)
+        {
+            return sfTransform_equal(ref this, ref transform);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Overload of binary operator * to combine two transforms.
         /// This call is equivalent to calling new Transform(left).Combine(right).
         /// </summary>
@@ -332,6 +357,9 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfTransform_scaleWithCenter(ref Transform transform, float scaleX, float scaleY, float centerX, float centerY);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern bool sfTransform_equal(ref Transform left, ref Transform right);
         #endregion
     }
 }

--- a/src/Graphics/VertexBuffer.cs
+++ b/src/Graphics/VertexBuffer.cs
@@ -1,0 +1,313 @@
+﻿using SFML.System;
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace SFML.Graphics
+{
+    public class VertexBuffer : ObjectBase, Drawable
+    {
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Usage specifiers
+        ///
+        /// If data is going to be updated once or more every frame,
+        /// set the usage to Stream. If data is going
+        /// to be set once and used for a long time without being
+        /// modified, set the usage to Static.
+        /// For everything else Dynamic should
+        /// be a good compromise.
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public enum UsageSpecifier
+        {
+            Stream,
+            Dynamic,
+            Static
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Whether or not the system supports vertex buffers
+        ///
+        /// This function should always be called before using
+        /// the vertex buffer features. If it returns false, then
+        /// any attempt to use sf::VertexBuffer will fail.
+        /// </summary>
+        ///////////////////////////////////////////////////////////
+        public static bool Available { get { return sfVertexBuffer_isAvailable(); } }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Create a new vertex buffer with a specific
+        /// PrimitiveType and usage specifier.
+        ///
+        /// Creates the vertex buffer, allocating enough graphcis
+        /// memory to hold \p vertexCount vertices, and sets its
+        /// primitive type to \p type and usage to \p usage.
+        /// </summary>
+        /// <param name="vertexCount">Amount of vertices</param>
+        /// <param name="primitiveType">Type of primitives</param>
+        /// <param name="usageType">Usage specifier</param>
+        ////////////////////////////////////////////////////////////
+        public VertexBuffer(uint vertexCount, PrimitiveType primitiveType, UsageSpecifier usageType)
+            : base(sfVertexBuffer_create(vertexCount, primitiveType, usageType))
+        {
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Construct the vertex buffer from another vertex array
+        /// </summary>
+        /// <param name="copy">VertexBuffer to copy</param>
+        ////////////////////////////////////////////////////////////
+        public VertexBuffer(VertexBuffer copy)
+            : base(sfVertexBuffer_copy(copy.CPointer))
+        {
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Total vertex count
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public uint VertexCount { get { return sfVertexBuffer_getVertexCount(CPointer); } }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// OpenGL handle of the vertex buffer or 0 if not yet created
+        /// 
+        /// You shouldn't need to use this property, unless you have
+        /// very specific stuff to implement that SFML doesn't support,
+        /// or implement a temporary workaround until a bug is fixed.
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public uint NativeHandle
+        {
+            get { return sfVertexBuffer_getNativeHandle(CPointer); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// The type of primitives drawn by the vertex buffer
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public PrimitiveType PrimitiveType
+        {
+            get { return sfVertexBuffer_getPrimitiveType(CPointer); }
+            set { sfVertexBuffer_setPrimitiveType(CPointer, value); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// The usage specifier for the vertex buffer
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public UsageSpecifier Usage
+        {
+            get { return sfVertexBuffer_getUsage(CPointer); }
+            set { sfVertexBuffer_setUsage(CPointer, value); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Update a part of the buffer from an array of vertices
+        /// offset is specified as the number of vertices to skip
+        /// from the beginning of the buffer.
+        ///
+        /// If offset is 0 and vertexCount is equal to the size of
+        /// the currently created buffer, its whole contents are replaced.
+        ///
+        /// If offset is 0 and vertexCount is greater than the
+        /// size of the currently created buffer, a new buffer is created
+        /// containing the vertex data.
+        ///
+        /// If offset is 0 and vertexCount is less than the size of
+        /// the currently created buffer, only the corresponding region
+        /// is updated.
+        ///
+        /// If offset is not 0 and offset + vertexCount is greater
+        /// than the size of the currently created buffer, the update fails.
+        ///
+        /// No additional check is performed on the size of the vertex
+        /// array, passing invalid arguments will lead to undefined
+        /// behavior.
+        /// </summary>
+        /// <param name="vertices">Array of vertices to copy to the buffer</param>
+        /// <param name="vertexCount">Number of vertices to copy</param>
+        /// <param name="offset">Offset in the buffer to copy to</param>
+        ////////////////////////////////////////////////////////////
+        public bool Update(Vertex[] vertices, uint vertexCount, uint offset)
+        {
+            unsafe
+            {
+                fixed (Vertex* verts = vertices)
+                {
+                    return sfVertexBuffer_update(CPointer, verts, vertexCount, offset);
+                }
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Update a part of the buffer from an array of vertices
+        /// assuming an offset of 0 and a vertex count the length of the passed array.
+        ///
+        /// If offset is 0 and vertexCount is equal to the size of
+        /// the currently created buffer, its whole contents are replaced.
+        ///
+        /// If offset is 0 and vertexCount is greater than the
+        /// size of the currently created buffer, a new buffer is created
+        /// containing the vertex data.
+        ///
+        /// If offset is 0 and vertexCount is less than the size of
+        /// the currently created buffer, only the corresponding region
+        /// is updated.
+        ///
+        /// If offset is not 0 and offset + vertexCount is greater
+        /// than the size of the currently created buffer, the update fails.
+        ///
+        /// No additional check is performed on the size of the vertex
+        /// array, passing invalid arguments will lead to undefined
+        /// behavior.
+        /// </summary>
+        /// <param name="vertices">Array of vertices to copy to the buffer</param>
+        ////////////////////////////////////////////////////////////
+        public bool Update(Vertex[] vertices)
+        {
+            return this.Update(vertices, (uint)vertices.Length, 0);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Update a part of the buffer from an array of vertices
+        /// assuming a vertex count the length of the passed array.
+        ///
+        /// If offset is 0 and vertexCount is equal to the size of
+        /// the currently created buffer, its whole contents are replaced.
+        ///
+        /// If offset is 0 and vertexCount is greater than the
+        /// size of the currently created buffer, a new buffer is created
+        /// containing the vertex data.
+        ///
+        /// If offset is 0 and vertexCount is less than the size of
+        /// the currently created buffer, only the corresponding region
+        /// is updated.
+        ///
+        /// If offset is not 0 and offset + vertexCount is greater
+        /// than the size of the currently created buffer, the update fails.
+        ///
+        /// No additional check is performed on the size of the vertex
+        /// array, passing invalid arguments will lead to undefined
+        /// behavior.
+        /// </summary>
+        /// <param name="vertices">Array of vertices to copy to the buffer</param>
+        /// <param name="offset">Offset in the buffer to copy to</param>
+        ////////////////////////////////////////////////////////////
+        public bool Update(Vertex[] vertices, uint offset)
+        {
+            return this.Update(vertices, (uint)vertices.Length, offset);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Copy the contents of another buffer into this buffer
+        /// </summary>
+        /// <param name="other">Vertex buffer whose contents to copy into first vertex buffer</param>
+        ////////////////////////////////////////////////////////////
+        public bool Update(VertexBuffer other)
+        {
+            return sfVertexBuffer_updateFromVertexBuffer(CPointer, other.CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Swap the contents of another buffer into this buffer
+        /// </summary>
+        /// <param name="other">Vertex buffer whose contents to swap with</param>
+        ////////////////////////////////////////////////////////////
+        public void Swap(VertexBuffer other)
+        {
+            sfVertexBuffer_swap(CPointer, other.CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Handle the destruction of the object
+        /// </summary>
+        /// <param name="disposing">Is the GC disposing the object, or is it an explicit call ?</param>
+        ////////////////////////////////////////////////////////////
+        protected override void Destroy(bool disposing)
+        {
+            sfVertexBuffer_destroy(CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Draw the vertex buffer to a render target
+        /// </summary>
+        /// <param name="target">Render target to draw to</param>
+        /// <param name="states">Current render states</param>
+        ////////////////////////////////////////////////////////////
+        public void Draw(RenderTarget target, RenderStates states)
+        {
+            RenderStates.MarshalData marshaledStates = states.Marshal();
+
+            if(target is RenderWindow)
+            {
+                sfRenderWindow_drawVertexBuffer(((RenderWindow)target).CPointer, CPointer, ref marshaledStates);
+            }
+            else if(target is RenderTexture)
+            {
+                sfRenderTexture_drawVertexBuffer(((RenderTexture)target).CPointer, CPointer, ref marshaledStates);
+            }
+        }
+
+        #region Imports
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern IntPtr sfVertexBuffer_create(uint vertexCount, PrimitiveType type, UsageSpecifier usage);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern IntPtr sfVertexBuffer_copy(IntPtr copy);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfVertexBuffer_destroy(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern uint sfVertexBuffer_getVertexCount(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern unsafe bool sfVertexBuffer_update(IntPtr CPointer, Vertex* vertices, uint vertexCount, uint offset);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern bool sfVertexBuffer_updateFromVertexBuffer(IntPtr CPointer, IntPtr other);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfVertexBuffer_swap(IntPtr CPointer, IntPtr other);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern uint sfVertexBuffer_getNativeHandle(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfVertexBuffer_setPrimitiveType(IntPtr CPointer, PrimitiveType primitiveType);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern PrimitiveType sfVertexBuffer_getPrimitiveType(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfVertexBuffer_setUsage(IntPtr CPointer, UsageSpecifier usageType);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern UsageSpecifier sfVertexBuffer_getUsage(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern bool sfVertexBuffer_isAvailable();
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfRenderWindow_drawVertexBuffer(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfRenderTexture_drawVertexBuffer(IntPtr CPointer, IntPtr VertexBuffer, ref RenderStates.MarshalData states);
+        #endregion
+    }
+}

--- a/src/Graphics/sfml-graphics.csproj
+++ b/src/Graphics/sfml-graphics.csproj
@@ -26,7 +26,7 @@
 		<IsOSX>False</IsOSX>
 		<IsAndroid>False</IsAndroid>
 		<IsLinux>False</IsLinux>
-		<Version>2.5.1</Version>
+		<Version>2.5.0</Version>
 		<Description>Graphics module of the SFML library</Description>
 	</PropertyGroup>
 

--- a/src/Graphics/sfml-graphics.csproj
+++ b/src/Graphics/sfml-graphics.csproj
@@ -26,7 +26,7 @@
 		<IsOSX>False</IsOSX>
 		<IsAndroid>False</IsAndroid>
 		<IsLinux>False</IsLinux>
-		<Version>2.4.2</Version>
+		<Version>2.5.1</Version>
 		<Description>Graphics module of the SFML library</Description>
 	</PropertyGroup>
 

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -2,9 +2,9 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyProduct("SFML")]
-[assembly: AssemblyCopyright("Copyright © Laurent Gomila")]
+[assembly: AssemblyCopyright("Copyright Â© Laurent Gomila")]
 
 [assembly: ComVisible(true)]
 
-[assembly: AssemblyVersion("2.5.1")]
-[assembly: AssemblyFileVersion("2.5.1")]
+[assembly: AssemblyVersion("2.5.0")]
+[assembly: AssemblyFileVersion("2.5.0")]

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -6,5 +6,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(true)]
 
-[assembly: AssemblyVersion("2.4.0")]
-[assembly: AssemblyFileVersion("2.4.0")]
+[assembly: AssemblyVersion("2.5.1")]
+[assembly: AssemblyFileVersion("2.5.1")]

--- a/src/System/sfml-system.csproj
+++ b/src/System/sfml-system.csproj
@@ -20,7 +20,7 @@
 		<IsOSX>False</IsOSX>
 		<IsAndroid>False</IsAndroid>
 		<IsLinux>False</IsLinux>
-		<Version>2.5.1</Version>
+		<Version>2.5.0</Version>
 		<Description>Core module of the SFML library</Description>
 	</PropertyGroup>
 

--- a/src/System/sfml-system.csproj
+++ b/src/System/sfml-system.csproj
@@ -20,7 +20,7 @@
 		<IsOSX>False</IsOSX>
 		<IsAndroid>False</IsAndroid>
 		<IsLinux>False</IsLinux>
-		<Version>2.4.2</Version>
+		<Version>2.5.1</Version>
 		<Description>Core module of the SFML library</Description>
 	</PropertyGroup>
 

--- a/src/Window/Clipboard.cs
+++ b/src/Window/Clipboard.cs
@@ -1,0 +1,54 @@
+﻿using SFML.System;
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+
+namespace SFML.Window
+{
+    public class Clipboard
+    {
+        /// <summary>
+        /// The contents of the Clipboard as a UTF-32 string
+        /// </summary>
+        public static string Contents
+        {
+            get
+            {
+                IntPtr source = sfClipboard_getUnicodeString();
+
+                uint length = 0;
+                unsafe
+                {
+                    for(uint* ptr = (uint*)source.ToPointer(); *ptr != 0; ++ptr)
+                    {
+                        length++;
+                    }
+                }
+                
+                byte[] sourceBytes = new byte[length * 4];
+                Marshal.Copy(source, sourceBytes, 0, sourceBytes.Length);
+                
+                return Encoding.UTF32.GetString(sourceBytes);
+            }
+            set
+            {
+                byte[] utf32 = Encoding.UTF32.GetBytes(value + '\0');
+
+                unsafe
+                {
+                    fixed (byte* ptr = utf32)
+                    {
+                        sfClipboard_setUnicodeString((IntPtr)ptr);
+                    }
+                }
+            }
+        }
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern IntPtr sfClipboard_getUnicodeString();
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfClipboard_setUnicodeString(IntPtr ptr);
+    }
+}

--- a/src/Window/Cursor.cs
+++ b/src/Window/Cursor.cs
@@ -1,0 +1,178 @@
+﻿using SFML;
+using SFML.System;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SFML.Window
+{
+    public class Cursor : ObjectBase
+    {
+        /// <summary>
+        /// Enumeration of possibly available native system cursor types
+        /// </summary>
+        public enum CursorType
+        {
+            /// <summary>
+            /// Arrow cursor (default)
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            Arrow,
+            /// <summary>
+            /// Busy arrow cursor
+            /// Windows: Yes
+            /// Mac OS:  No
+            /// Linux:   No
+            /// </summary>
+            ArrowWait,
+            /// <summary>
+            /// Busy cursor
+            /// Windows: Yes
+            /// Mac OS:  No
+            /// Linux:   Yes
+            /// </summary>
+            Wait,
+            /// <summary>
+            /// I-beam, cursor when hovering over a field allowing text entry
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            Text,
+            /// <summary>
+            /// Pointing hand cursor
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            Hand,
+            /// <summary>
+            /// Horizontal double arrow cursor
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeHorinzontal,
+            /// <summary>
+            /// Vertical double arrow cursor
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeVertical,
+            /// <summary>
+            /// Double arrow cursor going from top-left to bottom-right
+            /// Windows: Yes
+            /// Mac OS:  No
+            /// Linux:   No
+            /// </summary>
+            SizeTopLeftBottomRight,
+            /// <summary>
+            /// Double arrow cursor going from bottom-left to top-right
+            /// Windows: Yes
+            /// Mac OS:  No
+            /// Linux:   No
+            /// </summary>
+            SizeBottomLeftTopRight,
+            /// <summary>
+            /// Combination of SizeHorizontal and SizeVertical
+            /// Windows: Yes
+            /// Mac OS:  No
+            /// Linux:   Yes
+            /// </summary>
+            SizeAll,
+            /// <summary>
+            /// Crosshair cursor
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            Cross,
+            /// <summary>
+            /// Help cursor
+            /// Windows: Yes
+            /// Mac OS:  No
+            /// Linux:   Yes
+            /// </summary>
+            Help,
+            /// <summary>
+            /// Action not allowed cursor
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            NotAllowed
+        }
+
+        /// <summary>
+        /// Create a native system cursor
+        ///
+        /// Refer to the list of cursor available on each system
+        /// (see CursorType) to know whether a given cursor is
+        /// expected to load successfully or is not supported by
+        /// the operating system.
+        /// </summary>
+        /// <param name="type">System cursor type</param>
+        public Cursor(CursorType type)
+            : base(sfCursor_createFromSystem(type))
+        {
+        }
+
+        /// <summary>
+        /// Create a cursor with the provided image
+        ///
+        /// Pixels must be an array of width by height pixels
+        /// in 32-bit RGBA format. If not, this will cause undefined behavior.
+        ///
+        /// If pixels is null or either width or height are 0,
+        /// the current cursor is left unchanged and the function will
+        /// return false.
+        ///
+        /// In addition to specifying the pixel data, you can also
+        /// specify the location of the hotspot of the cursor. The
+        /// hotspot is the pixel coordinate within the cursor image
+        /// which will be located exactly where the mouse pointer
+        /// position is. Any mouse actions that are performed will
+        /// return the window/screen location of the hotspot.
+        ///
+        /// Warning: On Unix, the pixels are mapped into a monochrome
+        ///          bitmap: pixels with an alpha channel to 0 are
+        ///          transparent, black if the RGB channel are close
+        ///          to zero, and white otherwise.
+        /// </summary>
+        /// <param name="pixels">Array of pixels of the image</param>
+        /// <param name="size">Width and height of the image</param>
+        /// <param name="hotspot">(x,y) location of the hotspot</param>
+        public Cursor(byte[] pixels, SFML.System.Vector2u size, SFML.System.Vector2u hotspot)
+            : base((IntPtr)0)
+        {
+            unsafe
+            {
+                fixed (byte* ptr = pixels)
+                {
+                    CPointer = sfCursor_createFromPixels((IntPtr)ptr, size, hotspot);
+                }
+            }
+        }
+
+        protected override void Destroy(bool disposing)
+        {
+            sfCursor_destroy(CPointer);
+        }
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern IntPtr sfCursor_createFromSystem(CursorType type);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern IntPtr sfCursor_createFromPixels(IntPtr pixels, Vector2u size, Vector2u hotspot);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfCursor_destroy(IntPtr CPointer);
+    }
+}

--- a/src/Window/Keyboard.cs
+++ b/src/Window/Keyboard.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
@@ -117,7 +118,7 @@ namespace SFML.Window
             /// <summary>The ] key</summary>
             RBracket,
             /// <summary>The ; key</summary>
-            SemiColon,
+            Semicolon,
             /// <summary>The , key</summary>
             Comma,
             /// <summary>The . key</summary>
@@ -127,19 +128,19 @@ namespace SFML.Window
             /// <summary>The / key</summary>
             Slash,
             /// <summary>The \ key</summary>
-            BackSlash,
+            Backslash,
             /// <summary>The ~ key</summary>
             Tilde,
             /// <summary>The = key</summary>
             Equal,
             /// <summary>The - key</summary>
-            Dash,
+            Hyphen,
             /// <summary>The Space key</summary>
             Space,
             /// <summary>The Return key</summary>
-            Return,
+            Enter,
             /// <summary>The Backspace key</summary>
-            BackSpace,
+            Backspace,
             /// <summary>The Tabulation key</summary>
             Tab,
             /// <summary>The Page up key</summary>
@@ -224,7 +225,19 @@ namespace SFML.Window
             Pause,
 
             /// <summary>The total number of keyboard keys</summary>
-            KeyCount // Keep last
+            KeyCount, // Keep last
+
+            // Deprecated backwards compatible stuff
+            [Obsolete("Deprecated: Use Hyphen instead.")]
+            Dash = Hyphen,
+            [Obsolete("Deprecated: Use Backspace instead.")]
+            BackSpace = Backspace,
+            [Obsolete("Deprecated: Use Enter instead.")]
+            Return = Enter,
+            [Obsolete("Deprecated: Use Backslash instead.")]
+            BackSlash = Backslash,
+            [Obsolete("Deprecated: Use Semicolon instead.")]
+            SemiColon = Semicolon
         };
 
         ////////////////////////////////////////////////////////////

--- a/src/Window/Window.cs
+++ b/src/Window/Window.cs
@@ -263,6 +263,17 @@ namespace SFML.Window
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Set the displayed cursor to a native system cursor
+        /// </summary>
+        /// <param name="enable">True to enable v-sync, false to deactivate</param>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetMouseCursor(Cursor cursor)
+        {
+            sfWindow_setMouseCursor(CPointer, cursor.CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Enable / disable vertical synchronization
         /// </summary>
         /// <param name="enable">True to enable v-sync, false to deactivate</param>
@@ -824,6 +835,9 @@ namespace SFML.Window
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfWindow_setMouseCursorGrabbed(IntPtr CPointer, bool grabbed);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        static extern void sfWindow_setMouseCursor(IntPtr CPointer, IntPtr cursor);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfWindow_setVerticalSyncEnabled(IntPtr CPointer, bool Enable);

--- a/src/Window/sfml-window.csproj
+++ b/src/Window/sfml-window.csproj
@@ -6,7 +6,6 @@
 		<AssemblyName>sfml-window</AssemblyName>
 		<Configurations>Debug;Release;_WINDOWS_;_LINUX_;_OSX_</Configurations>
     <Description>Window module of the SFML library</Description>
-    <Version>2.4.2</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -22,7 +21,7 @@
 		<IsOSX>False</IsOSX>
 		<IsAndroid>False</IsAndroid>
 		<IsLinux>False</IsLinux>
-		<Version>2.4.2</Version>
+		<Version>2.5.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='_OSX_|AnyCPU'">

--- a/src/Window/sfml-window.csproj
+++ b/src/Window/sfml-window.csproj
@@ -21,7 +21,7 @@
 		<IsOSX>False</IsOSX>
 		<IsAndroid>False</IsAndroid>
 		<IsLinux>False</IsLinux>
-		<Version>2.5.1</Version>
+		<Version>2.5.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='_OSX_|AnyCPU'">


### PR DESCRIPTION
This brings SFML.Net up to SFML 2.5. Additionally addresses #156 by switching the Font(byte[]) constructor to convert the raw byte[] to a MemoryStream and calling Font(Stream) instead