### PR TITLE
Time Division Scalar

### DIFF
--- a/src/SFML.System/Time.cs
+++ b/src/SFML.System/Time.cs
@@ -187,7 +187,7 @@ namespace SFML.System
         /// </summary>
         /// <returns>left divided by the right</returns>
         ////////////////////////////////////////////////////////////
-        public static Time operator /(Time left, Time right) => FromMicroseconds(left.AsMicroseconds() / right.AsMicroseconds());
+        public static float operator /(Time left, Time right) => left.AsSeconds() / right.AsSeconds();
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.Window/Cursor.cs
+++ b/src/SFML.Window/Cursor.cs
@@ -61,7 +61,7 @@ namespace SFML.Window
             /// Mac OS:  Yes
             /// Linux:   Yes
             /// </summary>
-            SizeHorinzontal,
+            SizeHorizontal,
             /// <summary>
             /// Vertical double arrow cursor
             /// Windows: Yes


### PR DESCRIPTION
Additionally, corrected a typo in CursorType enum (SizeHorinzontal)

This PR corrects issues #176 and #177 

A separate PR for a simple spelling change did not seem logical.