### PR TITLE
Update Time.cs

### DIFF
--- a/src/SFML.System/Time.cs
+++ b/src/SFML.System/Time.cs
@@ -48,24 +48,47 @@ namespace SFML.System
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Construct a Time value from a TimeSpan
+        /// </summary>
+        /// <param name="timeSpan">A TimeSpan representing the amount of time to represent</param>
+        /// <returns>Time value constructed from an existing TimeSpan</returns>
+        ////////////////////////////////////////////////////////////
+        public static Time FromTimeSpan(TimeSpan timeSpan) => sfMicroseconds(timeSpan.Ticks * 1000 / TimeSpan.TicksPerMillisecond);
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Returns the time value as a number of seconds
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public float AsSeconds() => sfTime_asSeconds(this);
+        public float AsSeconds() => microseconds / 1000000f;
 
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Returns the time value as a number of milliseconds
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public int AsMilliseconds() => sfTime_asMilliseconds(this);
+        public int AsMilliseconds() => (int)(microseconds / 1000);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Returns the time value as a number of microseconds
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public long AsMicroseconds() => sfTime_asMicroseconds(this);
+        public long AsMicroseconds() => microseconds;
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Returns the time value as a TimeSpan
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public TimeSpan ToTimeSpan() => TimeSpan.FromTicks(microseconds * (TimeSpan.TicksPerMillisecond / 1000));
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Implicit conversion from TimeSpan to SFML.System.Time, allowing intuitive use
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public static implicit operator Time(TimeSpan timeSpan) => FromTimeSpan(timeSpan);
 
         ////////////////////////////////////////////////////////////
         /// <summary>


### PR DESCRIPTION
Added conversions to and from .NET's TimeSpan struct
Significantly reduced P/Invoke calls, which now only happen during construction and conversion

This should yield performance gains in any place where Time is being used. Additionally, this is a bit of futureproofing for SFML3, as Time is likely to be removed, and the TimeSpan struct has existed in .NET since Framework 1.0