### PR TITLE
Update RenderTexture's ctor import

### DIFF
--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -54,7 +54,7 @@ namespace SFML.Graphics
         /// <param name="contextSettings">A ContextSettings struct representing settings for the RenderTexture</param>
         ////////////////////////////////////////////////////////////
         public RenderTexture(uint width, uint height, ContextSettings contextSettings) :
-            base(sfRenderTexture_createWithSettings(width, height, ref contextSettings))
+            base(sfRenderTexture_create(width, height, ref contextSettings))
         {
             myDefaultView = new View(sfRenderTexture_getDefaultView(CPointer));
             myTexture = new Texture(sfRenderTexture_getTexture(CPointer));
@@ -530,7 +530,7 @@ namespace SFML.Graphics
         static extern IntPtr sfRenderTexture_create(uint Width, uint Height, bool DepthBuffer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderTexture_createWithSettings(uint Width, uint Height, ref ContextSettings Settings);
+        static extern IntPtr sfRenderTexture_create(uint Width, uint Height, ref ContextSettings Settings);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern void sfRenderTexture_destroy(IntPtr CPointer);


### PR DESCRIPTION
The RenderTexture constructor used in SFML.NET, `createWithSettings`, does not exist in CSFML 2.5 and causes exceptions when attempting to create a RenderTarget instance.
Unless I'm mistaken, this should be `create`. 