### PR TITLE
Add an allocation-free alternative to Image.Pixels

### DIFF
--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -299,6 +299,24 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Copy the array of pixels (RGBA 8 bits integers
+        /// components) to the provided buffer.
+        /// Buffer size must be at least Width x Height x 4
+        /// </summary>
+        /// <param name="buffer">Buffer to copy to</param>
+        ////////////////////////////////////////////////////////////
+        public void CopyPixels(byte[] buffer)
+        {
+            Vector2u size = Size;
+            if (buffer.Length < size.X * size.Y * 4)
+            {
+                throw new ArgumentException("Buffer must have a size of at least Width * Height * 4 bytes", nameof(buffer));
+            }
+            Marshal.Copy(sfImage_getPixelsPtr(CPointer), buffer, 0, (int)(size.X * size.Y * 4));
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Size of the image, in pixels
         /// </summary>
         ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently, there are two ways to access the pixels of an `Image`.

The first one is `Image.GetPixel()`, which does a call to a native function on each invocation, which is pretty bad for performance if you do it millions of times per second.

The other one is `Image.Pixels`  
It allocates a new pixel buffer on each getter access. Property accessors should never do anything heavy inside of them (according to common sense and [the official design guidelines](https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/ms229054(v=vs.100))), you can easily shoot yourself in the foot by writing a naïve code like this:  
```csharp
for (int y = 0; y < image.Size.Y; y++)
{
    for (int x = 0; x < image.Size.X; x++)
    {
        // Do something with image.Pixels[(y * image.Size.X + x) * 4]
    }
}
```  
Which _seems_ faster than calling `Image.GetPixel()`, but is actually `O(W * H)` allocations of `O(W * H)` bytes!

This pull request adds a new allocation-free and more performant alternative, which copies the internal pixel buffer to a user-provider byte array, and is a safer alternative to #138.

And I would also recommend you to deprecate `Image.Pixels` for the reasons stated above.