### PR TITLE
Adds null check to GetPointCount

### DIFF
--- a/src/SFML.Graphics/ConvexShape.cs
+++ b/src/SFML.Graphics/ConvexShape.cs
@@ -49,7 +49,7 @@ namespace SFML.Graphics
         /// </summary>
         /// <returns>The total point count</returns>
         ////////////////////////////////////////////////////////////
-        public override uint GetPointCount() => (uint)myPoints.Length;
+        public override uint GetPointCount() => (uint)(myPoints?.Length ?? 0);
 
         ////////////////////////////////////////////////////////////
         /// <summary>


### PR DESCRIPTION
This makes sure point count is zero during initialisation as its called indirectly from Shape base copy constructor

A quick fix for #203 