### PR TITLE
Fix #207

### DIFF
--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -414,7 +414,7 @@ namespace SFML.Audio
         static extern TimeSpan sfMusic_getLoopPoints(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern TimeSpan sfMusic_setLoopPoints(IntPtr Music, TimeSpan timePoints);
+        static extern void sfMusic_setLoopPoints(IntPtr Music, TimeSpan timePoints);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         static extern uint sfMusic_getChannelCount(IntPtr Music);

--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -360,8 +360,26 @@ namespace SFML.Audio
         [StructLayout(LayoutKind.Sequential)]
         public struct TimeSpan
         {
-            Time offset;
-            Time length;
+            /// <summary>
+            /// Constructs TimeSpan from offset and a length
+            /// </summary>
+            /// <param name="offset">beginning offset of the time range</param>
+            /// <param name="length">length of the time range</param>
+            public TimeSpan(Time offset, Time length)
+            {
+                Offset = offset;
+                Length = length;
+            }
+
+            /// <summary>
+            /// The beginning of the time range
+            /// </summary>
+            public Time Offset;
+
+            /// <summary>
+            /// The length of the time range
+            /// </summary>
+            public Time Length;
         }
 
         #region Imports


### PR DESCRIPTION
Fix #207 
Makes Music.TimeSpan fields public

For maintainers;
I used [Rect.cs](https://github.com/SFML/SFML.Net/blob/master/src/SFML.Graphics/Rect.cs#L209) as a reference on how to make TimeSpan fields public. This means I've changed the field names to be capitalised and haven't used properties. As the fields were never accessible even internally to start with, the name change shouldn't cause a API breaking change.