### PR TITLE
FIxes Missing Access Modifier Warnings

### DIFF
--- a/src/SFML.Audio/Listener.cs
+++ b/src/SFML.Audio/Listener.cs
@@ -70,28 +70,28 @@ namespace SFML.Audio
 
         #region Imports
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfListener_setGlobalVolume(float Volume);
+        private static extern void sfListener_setGlobalVolume(float Volume);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfListener_getGlobalVolume();
+        private static extern float sfListener_getGlobalVolume();
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfListener_setPosition(Vector3f position);
+        private static extern void sfListener_setPosition(Vector3f position);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector3f sfListener_getPosition();
+        private static extern Vector3f sfListener_getPosition();
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfListener_setDirection(Vector3f direction);
+        private static extern void sfListener_setDirection(Vector3f direction);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector3f sfListener_getDirection();
+        private static extern Vector3f sfListener_getDirection();
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfListener_setUpVector(Vector3f upVector);
+        private static extern void sfListener_setUpVector(Vector3f upVector);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector3f sfListener_getUpVector();
+        private static extern Vector3f sfListener_getUpVector();
         #endregion
     }
 }

--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -384,91 +384,91 @@ namespace SFML.Audio
 
         #region Imports
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfMusic_createFromFile(string Filename);
+        private static extern IntPtr sfMusic_createFromFile(string Filename);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern IntPtr sfMusic_createFromStream(IntPtr stream);
+        private unsafe static extern IntPtr sfMusic_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfMusic_createFromMemory(IntPtr data, ulong size);
+        private static extern IntPtr sfMusic_createFromMemory(IntPtr data, ulong size);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_destroy(IntPtr MusicStream);
+        private static extern void sfMusic_destroy(IntPtr MusicStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_play(IntPtr Music);
+        private static extern void sfMusic_play(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_pause(IntPtr Music);
+        private static extern void sfMusic_pause(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_stop(IntPtr Music);
+        private static extern void sfMusic_stop(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern SoundStatus sfMusic_getStatus(IntPtr Music);
+        private static extern SoundStatus sfMusic_getStatus(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfMusic_getDuration(IntPtr Music);
+        private static extern Time sfMusic_getDuration(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern TimeSpan sfMusic_getLoopPoints(IntPtr Music);
+        private static extern TimeSpan sfMusic_getLoopPoints(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setLoopPoints(IntPtr Music, TimeSpan timePoints);
+        private static extern void sfMusic_setLoopPoints(IntPtr Music, TimeSpan timePoints);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfMusic_getChannelCount(IntPtr Music);
+        private static extern uint sfMusic_getChannelCount(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfMusic_getSampleRate(IntPtr Music);
+        private static extern uint sfMusic_getSampleRate(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setPitch(IntPtr Music, float Pitch);
+        private static extern void sfMusic_setPitch(IntPtr Music, float Pitch);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setLoop(IntPtr Music, bool Loop);
+        private static extern void sfMusic_setLoop(IntPtr Music, bool Loop);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setVolume(IntPtr Music, float Volume);
+        private static extern void sfMusic_setVolume(IntPtr Music, float Volume);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setPosition(IntPtr Music, Vector3f position);
+        private static extern void sfMusic_setPosition(IntPtr Music, Vector3f position);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setRelativeToListener(IntPtr Music, bool Relative);
+        private static extern void sfMusic_setRelativeToListener(IntPtr Music, bool Relative);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setMinDistance(IntPtr Music, float MinDistance);
+        private static extern void sfMusic_setMinDistance(IntPtr Music, float MinDistance);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setAttenuation(IntPtr Music, float Attenuation);
+        private static extern void sfMusic_setAttenuation(IntPtr Music, float Attenuation);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMusic_setPlayingOffset(IntPtr Music, Time TimeOffset);
+        private static extern void sfMusic_setPlayingOffset(IntPtr Music, Time TimeOffset);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfMusic_getLoop(IntPtr Music);
+        private static extern bool sfMusic_getLoop(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfMusic_getPitch(IntPtr Music);
+        private static extern float sfMusic_getPitch(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfMusic_getVolume(IntPtr Music);
+        private static extern float sfMusic_getVolume(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector3f sfMusic_getPosition(IntPtr Music);
+        private static extern Vector3f sfMusic_getPosition(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfMusic_isRelativeToListener(IntPtr Music);
+        private static extern bool sfMusic_isRelativeToListener(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfMusic_getMinDistance(IntPtr Music);
+        private static extern float sfMusic_getMinDistance(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfMusic_getAttenuation(IntPtr Music);
+        private static extern float sfMusic_getAttenuation(IntPtr Music);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfMusic_getPlayingOffset(IntPtr Music);
+        private static extern Time sfMusic_getPlayingOffset(IntPtr Music);
         #endregion
     }
 }

--- a/src/SFML.Audio/Sound.cs
+++ b/src/SFML.Audio/Sound.cs
@@ -298,79 +298,79 @@ namespace SFML.Audio
 
         #region Imports
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSound_create();
+        private static extern IntPtr sfSound_create();
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSound_copy(IntPtr Sound);
+        private static extern IntPtr sfSound_copy(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_destroy(IntPtr Sound);
+        private static extern void sfSound_destroy(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_play(IntPtr Sound);
+        private static extern void sfSound_play(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_pause(IntPtr Sound);
+        private static extern void sfSound_pause(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_stop(IntPtr Sound);
+        private static extern void sfSound_stop(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setBuffer(IntPtr Sound, IntPtr Buffer);
+        private static extern void sfSound_setBuffer(IntPtr Sound, IntPtr Buffer);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSound_getBuffer(IntPtr Sound);
+        private static extern IntPtr sfSound_getBuffer(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setLoop(IntPtr Sound, bool Loop);
+        private static extern void sfSound_setLoop(IntPtr Sound, bool Loop);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSound_getLoop(IntPtr Sound);
+        private static extern bool sfSound_getLoop(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern SoundStatus sfSound_getStatus(IntPtr Sound);
+        private static extern SoundStatus sfSound_getStatus(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setPitch(IntPtr Sound, float Pitch);
+        private static extern void sfSound_setPitch(IntPtr Sound, float Pitch);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setVolume(IntPtr Sound, float Volume);
+        private static extern void sfSound_setVolume(IntPtr Sound, float Volume);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setPosition(IntPtr Sound, Vector3f position);
+        private static extern void sfSound_setPosition(IntPtr Sound, Vector3f position);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setRelativeToListener(IntPtr Sound, bool Relative);
+        private static extern void sfSound_setRelativeToListener(IntPtr Sound, bool Relative);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setMinDistance(IntPtr Sound, float MinDistance);
+        private static extern void sfSound_setMinDistance(IntPtr Sound, float MinDistance);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setAttenuation(IntPtr Sound, float Attenuation);
+        private static extern void sfSound_setAttenuation(IntPtr Sound, float Attenuation);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSound_setPlayingOffset(IntPtr Sound, Time TimeOffset);
+        private static extern void sfSound_setPlayingOffset(IntPtr Sound, Time TimeOffset);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfSound_getPitch(IntPtr Sound);
+        private static extern float sfSound_getPitch(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfSound_getVolume(IntPtr Sound);
+        private static extern float sfSound_getVolume(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector3f sfSound_getPosition(IntPtr Sound);
+        private static extern Vector3f sfSound_getPosition(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSound_isRelativeToListener(IntPtr Sound);
+        private static extern bool sfSound_isRelativeToListener(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfSound_getMinDistance(IntPtr Sound);
+        private static extern float sfSound_getMinDistance(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfSound_getAttenuation(IntPtr Sound);
+        private static extern float sfSound_getAttenuation(IntPtr Sound);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfSound_getPlayingOffset(IntPtr Sound);
+        private static extern Time sfSound_getPlayingOffset(IntPtr Sound);
         #endregion
     }
 }

--- a/src/SFML.Audio/SoundBuffer.cs
+++ b/src/SFML.Audio/SoundBuffer.cs
@@ -218,40 +218,40 @@ namespace SFML.Audio
 
         #region Imports
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSoundBuffer_createFromFile(string Filename);
+        private static extern IntPtr sfSoundBuffer_createFromFile(string Filename);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern IntPtr sfSoundBuffer_createFromStream(IntPtr stream);
+        private unsafe static extern IntPtr sfSoundBuffer_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern IntPtr sfSoundBuffer_createFromMemory(IntPtr data, ulong size);
+        private unsafe static extern IntPtr sfSoundBuffer_createFromMemory(IntPtr data, ulong size);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern IntPtr sfSoundBuffer_createFromSamples(short* Samples, ulong SampleCount, uint ChannelsCount, uint SampleRate);
+        private unsafe static extern IntPtr sfSoundBuffer_createFromSamples(short* Samples, ulong SampleCount, uint ChannelsCount, uint SampleRate);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSoundBuffer_copy(IntPtr SoundBuffer);
+        private static extern IntPtr sfSoundBuffer_copy(IntPtr SoundBuffer);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundBuffer_destroy(IntPtr SoundBuffer);
+        private static extern void sfSoundBuffer_destroy(IntPtr SoundBuffer);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSoundBuffer_saveToFile(IntPtr SoundBuffer, string Filename);
+        private static extern bool sfSoundBuffer_saveToFile(IntPtr SoundBuffer, string Filename);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSoundBuffer_getSamples(IntPtr SoundBuffer);
+        private static extern IntPtr sfSoundBuffer_getSamples(IntPtr SoundBuffer);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern ulong sfSoundBuffer_getSampleCount(IntPtr SoundBuffer);
+        private static extern ulong sfSoundBuffer_getSampleCount(IntPtr SoundBuffer);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfSoundBuffer_getSampleRate(IntPtr SoundBuffer);
+        private static extern uint sfSoundBuffer_getSampleRate(IntPtr SoundBuffer);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfSoundBuffer_getChannelCount(IntPtr SoundBuffer);
+        private static extern uint sfSoundBuffer_getChannelCount(IntPtr SoundBuffer);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfSoundBuffer_getDuration(IntPtr SoundBuffer);
+        private static extern Time sfSoundBuffer_getDuration(IntPtr SoundBuffer);
         #endregion
     }
 }

--- a/src/SFML.Audio/SoundRecorder.cs
+++ b/src/SFML.Audio/SoundRecorder.cs
@@ -294,43 +294,43 @@ namespace SFML.Audio
 
         #region Imports
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSoundRecorder_create(StartCallback OnStart, ProcessCallback OnProcess, StopCallback OnStop, IntPtr UserData);
+        private static extern IntPtr sfSoundRecorder_create(StartCallback OnStart, ProcessCallback OnProcess, StopCallback OnStop, IntPtr UserData);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundRecorder_destroy(IntPtr SoundRecorder);
+        private static extern void sfSoundRecorder_destroy(IntPtr SoundRecorder);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSoundRecorder_start(IntPtr SoundRecorder, uint SampleRate);
+        private static extern bool sfSoundRecorder_start(IntPtr SoundRecorder, uint SampleRate);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundRecorder_stop(IntPtr SoundRecorder);
+        private static extern void sfSoundRecorder_stop(IntPtr SoundRecorder);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfSoundRecorder_getSampleRate(IntPtr SoundRecorder);
+        private static extern uint sfSoundRecorder_getSampleRate(IntPtr SoundRecorder);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSoundRecorder_isAvailable();
+        private static extern bool sfSoundRecorder_isAvailable();
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundRecorder_setProcessingInterval(IntPtr SoundRecorder, Time Interval);
+        private static extern void sfSoundRecorder_setProcessingInterval(IntPtr SoundRecorder, Time Interval);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern IntPtr* sfSoundRecorder_getAvailableDevices(out uint Count);
+        private unsafe static extern IntPtr* sfSoundRecorder_getAvailableDevices(out uint Count);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSoundRecorder_getDefaultDevice();
+        private static extern IntPtr sfSoundRecorder_getDefaultDevice();
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSoundRecorder_setDevice(IntPtr SoundRecorder, string Name);
+        private static extern bool sfSoundRecorder_setDevice(IntPtr SoundRecorder, string Name);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSoundRecorder_getDevice(IntPtr SoundRecorder);
+        private static extern IntPtr sfSoundRecorder_getDevice(IntPtr SoundRecorder);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundRecorder_setChannelCount(IntPtr SoundRecorder, uint channelCount);
+        private static extern void sfSoundRecorder_setChannelCount(IntPtr SoundRecorder, uint channelCount);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfSoundRecorder_getChannelCount(IntPtr SoundRecorder);
+        private static extern uint sfSoundRecorder_getChannelCount(IntPtr SoundRecorder);
         #endregion
     }
 }

--- a/src/SFML.Audio/SoundStream.cs
+++ b/src/SFML.Audio/SoundStream.cs
@@ -359,76 +359,76 @@ namespace SFML.Audio
 
         #region Imports
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSoundStream_create(GetDataCallbackType OnGetData, SeekCallbackType OnSeek, uint ChannelCount, uint SampleRate, IntPtr UserData);
+        private static extern IntPtr sfSoundStream_create(GetDataCallbackType OnGetData, SeekCallbackType OnSeek, uint ChannelCount, uint SampleRate, IntPtr UserData);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_destroy(IntPtr SoundStreamStream);
+        private static extern void sfSoundStream_destroy(IntPtr SoundStreamStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_play(IntPtr SoundStream);
+        private static extern void sfSoundStream_play(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_pause(IntPtr SoundStream);
+        private static extern void sfSoundStream_pause(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_stop(IntPtr SoundStream);
+        private static extern void sfSoundStream_stop(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern SoundStatus sfSoundStream_getStatus(IntPtr SoundStream);
+        private static extern SoundStatus sfSoundStream_getStatus(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfSoundStream_getChannelCount(IntPtr SoundStream);
+        private static extern uint sfSoundStream_getChannelCount(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfSoundStream_getSampleRate(IntPtr SoundStream);
+        private static extern uint sfSoundStream_getSampleRate(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_setLoop(IntPtr SoundStream, bool Loop);
+        private static extern void sfSoundStream_setLoop(IntPtr SoundStream, bool Loop);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_setPitch(IntPtr SoundStream, float Pitch);
+        private static extern void sfSoundStream_setPitch(IntPtr SoundStream, float Pitch);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_setVolume(IntPtr SoundStream, float Volume);
+        private static extern void sfSoundStream_setVolume(IntPtr SoundStream, float Volume);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_setPosition(IntPtr SoundStream, Vector3f position);
+        private static extern void sfSoundStream_setPosition(IntPtr SoundStream, Vector3f position);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_setRelativeToListener(IntPtr SoundStream, bool Relative);
+        private static extern void sfSoundStream_setRelativeToListener(IntPtr SoundStream, bool Relative);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_setMinDistance(IntPtr SoundStream, float MinDistance);
+        private static extern void sfSoundStream_setMinDistance(IntPtr SoundStream, float MinDistance);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_setAttenuation(IntPtr SoundStream, float Attenuation);
+        private static extern void sfSoundStream_setAttenuation(IntPtr SoundStream, float Attenuation);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSoundStream_setPlayingOffset(IntPtr SoundStream, Time TimeOffset);
+        private static extern void sfSoundStream_setPlayingOffset(IntPtr SoundStream, Time TimeOffset);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSoundStream_getLoop(IntPtr SoundStream);
+        private static extern bool sfSoundStream_getLoop(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfSoundStream_getPitch(IntPtr SoundStream);
+        private static extern float sfSoundStream_getPitch(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfSoundStream_getVolume(IntPtr SoundStream);
+        private static extern float sfSoundStream_getVolume(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector3f sfSoundStream_getPosition(IntPtr SoundStream);
+        private static extern Vector3f sfSoundStream_getPosition(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSoundStream_isRelativeToListener(IntPtr SoundStream);
+        private static extern bool sfSoundStream_isRelativeToListener(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfSoundStream_getMinDistance(IntPtr SoundStream);
+        private static extern float sfSoundStream_getMinDistance(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfSoundStream_getAttenuation(IntPtr SoundStream);
+        private static extern float sfSoundStream_getAttenuation(IntPtr SoundStream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfSoundStream_getPlayingOffset(IntPtr SoundStream);
+        private static extern Time sfSoundStream_getPlayingOffset(IntPtr SoundStream);
         #endregion
     }
 }

--- a/src/SFML.Graphics/Font.cs
+++ b/src/SFML.Graphics/Font.cs
@@ -224,40 +224,40 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfFont_createFromFile(string Filename);
+        private static extern IntPtr sfFont_createFromFile(string Filename);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfFont_createFromStream(IntPtr stream);
+        private static extern IntPtr sfFont_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfFont_createFromMemory(IntPtr data, ulong size);
+        private static extern IntPtr sfFont_createFromMemory(IntPtr data, ulong size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfFont_copy(IntPtr Font);
+        private static extern IntPtr sfFont_copy(IntPtr Font);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfFont_destroy(IntPtr CPointer);
+        private static extern void sfFont_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Glyph sfFont_getGlyph(IntPtr CPointer, uint codePoint, uint characterSize, bool bold, float outlineThickness);
+        private static extern Glyph sfFont_getGlyph(IntPtr CPointer, uint codePoint, uint characterSize, bool bold, float outlineThickness);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfFont_getKerning(IntPtr CPointer, uint first, uint second, uint characterSize);
+        private static extern float sfFont_getKerning(IntPtr CPointer, uint first, uint second, uint characterSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfFont_getLineSpacing(IntPtr CPointer, uint characterSize);
+        private static extern float sfFont_getLineSpacing(IntPtr CPointer, uint characterSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfFont_getUnderlinePosition(IntPtr CPointer, uint characterSize);
+        private static extern float sfFont_getUnderlinePosition(IntPtr CPointer, uint characterSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfFont_getUnderlineThickness(IntPtr CPointer, uint characterSize);
+        private static extern float sfFont_getUnderlineThickness(IntPtr CPointer, uint characterSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfFont_getTexture(IntPtr CPointer, uint characterSize);
+        private static extern IntPtr sfFont_getTexture(IntPtr CPointer, uint characterSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern InfoMarshalData sfFont_getInfo(IntPtr CPointer);
+        private static extern InfoMarshalData sfFont_getInfo(IntPtr CPointer);
         #endregion
     }
 }

--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -353,52 +353,52 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfImage_createFromColor(uint Width, uint Height, Color Col);
+        private static extern IntPtr sfImage_createFromColor(uint Width, uint Height, Color Col);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern IntPtr sfImage_createFromPixels(uint Width, uint Height, byte* Pixels);
+        private unsafe static extern IntPtr sfImage_createFromPixels(uint Width, uint Height, byte* Pixels);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfImage_createFromFile(string Filename);
+        private static extern IntPtr sfImage_createFromFile(string Filename);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern IntPtr sfImage_createFromStream(IntPtr stream);
+        private unsafe static extern IntPtr sfImage_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern IntPtr sfImage_createFromMemory(IntPtr data, ulong size);
+        private unsafe static extern IntPtr sfImage_createFromMemory(IntPtr data, ulong size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfImage_copy(IntPtr Image);
+        private static extern IntPtr sfImage_copy(IntPtr Image);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfImage_destroy(IntPtr CPointer);
+        private static extern void sfImage_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfImage_saveToFile(IntPtr CPointer, string Filename);
+        private static extern bool sfImage_saveToFile(IntPtr CPointer, string Filename);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfImage_createMaskFromColor(IntPtr CPointer, Color Col, byte Alpha);
+        private static extern void sfImage_createMaskFromColor(IntPtr CPointer, Color Col, byte Alpha);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfImage_copyImage(IntPtr CPointer, IntPtr Source, uint DestX, uint DestY, IntRect SourceRect, bool applyAlpha);
+        private static extern void sfImage_copyImage(IntPtr CPointer, IntPtr Source, uint DestX, uint DestY, IntRect SourceRect, bool applyAlpha);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfImage_setPixel(IntPtr CPointer, uint X, uint Y, Color Col);
+        private static extern void sfImage_setPixel(IntPtr CPointer, uint X, uint Y, Color Col);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Color sfImage_getPixel(IntPtr CPointer, uint X, uint Y);
+        private static extern Color sfImage_getPixel(IntPtr CPointer, uint X, uint Y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfImage_getPixelsPtr(IntPtr CPointer);
+        private static extern IntPtr sfImage_getPixelsPtr(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2u sfImage_getSize(IntPtr CPointer);
+        private static extern Vector2u sfImage_getSize(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfImage_flipHorizontally(IntPtr CPointer);
+        private static extern uint sfImage_flipHorizontally(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfImage_flipVertically(IntPtr CPointer);
+        private static extern uint sfImage_flipVertically(IntPtr CPointer);
         #endregion
     }
 }

--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -527,82 +527,82 @@ namespace SFML.Graphics
         #region Imports
         [Obsolete("sfRenderTexture_create is obselete. Use sfRenderTexture_createWithSettings instead.")]
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderTexture_create(uint Width, uint Height, bool DepthBuffer);
+        private static extern IntPtr sfRenderTexture_create(uint Width, uint Height, bool DepthBuffer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderTexture_createWithSettings(uint Width, uint Height, ref ContextSettings Settings);
+        private static extern IntPtr sfRenderTexture_createWithSettings(uint Width, uint Height, ref ContextSettings Settings);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_destroy(IntPtr CPointer);
+        private static extern void sfRenderTexture_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_clear(IntPtr CPointer, Color ClearColor);
+        private static extern void sfRenderTexture_clear(IntPtr CPointer, Color ClearColor);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2u sfRenderTexture_getSize(IntPtr CPointer);
+        private static extern Vector2u sfRenderTexture_getSize(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderTexture_setActive(IntPtr CPointer, bool Active);
+        private static extern bool sfRenderTexture_setActive(IntPtr CPointer, bool Active);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderTexture_saveGLStates(IntPtr CPointer);
+        private static extern bool sfRenderTexture_saveGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderTexture_restoreGLStates(IntPtr CPointer);
+        private static extern bool sfRenderTexture_restoreGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderTexture_display(IntPtr CPointer);
+        private static extern bool sfRenderTexture_display(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_setView(IntPtr CPointer, IntPtr View);
+        private static extern void sfRenderTexture_setView(IntPtr CPointer, IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderTexture_getView(IntPtr CPointer);
+        private static extern IntPtr sfRenderTexture_getView(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderTexture_getDefaultView(IntPtr CPointer);
+        private static extern IntPtr sfRenderTexture_getDefaultView(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntRect sfRenderTexture_getViewport(IntPtr CPointer, IntPtr TargetView);
+        private static extern IntRect sfRenderTexture_getViewport(IntPtr CPointer, IntPtr TargetView);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfRenderTexture_mapCoordsToPixel(IntPtr CPointer, Vector2f point, IntPtr View);
+        private static extern Vector2i sfRenderTexture_mapCoordsToPixel(IntPtr CPointer, Vector2f point, IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2f sfRenderTexture_mapPixelToCoords(IntPtr CPointer, Vector2i point, IntPtr View);
+        private static extern Vector2f sfRenderTexture_mapPixelToCoords(IntPtr CPointer, Vector2i point, IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderTexture_getTexture(IntPtr CPointer);
+        private static extern IntPtr sfRenderTexture_getTexture(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfRenderTexture_getMaximumAntialiasingLevel();
+        private static extern uint sfRenderTexture_getMaximumAntialiasingLevel();
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_setSmooth(IntPtr CPointer, bool smooth);
+        private static extern void sfRenderTexture_setSmooth(IntPtr CPointer, bool smooth);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderTexture_isSmooth(IntPtr CPointer);
+        private static extern bool sfRenderTexture_isSmooth(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_setRepeated(IntPtr CPointer, bool repeated);
+        private static extern void sfRenderTexture_setRepeated(IntPtr CPointer, bool repeated);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderTexture_isRepeated(IntPtr CPointer);
+        private static extern bool sfRenderTexture_isRepeated(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderTexture_generateMipmap(IntPtr CPointer);
+        private static extern bool sfRenderTexture_generateMipmap(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern void sfRenderTexture_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, uint vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
+        private unsafe static extern void sfRenderTexture_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, uint vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_pushGLStates(IntPtr CPointer);
+        private static extern void sfRenderTexture_pushGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_popGLStates(IntPtr CPointer);
+        private static extern void sfRenderTexture_popGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_resetGLStates(IntPtr CPointer);
+        private static extern void sfRenderTexture_resetGLStates(IntPtr CPointer);
         #endregion
     }
 }

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -795,145 +795,145 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderWindow_create(VideoMode Mode, string Title, Styles Style, ref ContextSettings Params);
+        private static extern IntPtr sfRenderWindow_create(VideoMode Mode, string Title, Styles Style, ref ContextSettings Params);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderWindow_createUnicode(VideoMode Mode, IntPtr Title, Styles Style, ref ContextSettings Params);
+        private static extern IntPtr sfRenderWindow_createUnicode(VideoMode Mode, IntPtr Title, Styles Style, ref ContextSettings Params);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderWindow_createFromHandle(IntPtr Handle, ref ContextSettings Params);
+        private static extern IntPtr sfRenderWindow_createFromHandle(IntPtr Handle, ref ContextSettings Params);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_destroy(IntPtr CPointer);
+        private static extern void sfRenderWindow_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_close(IntPtr CPointer);
+        private static extern void sfRenderWindow_close(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderWindow_isOpen(IntPtr CPointer);
+        private static extern bool sfRenderWindow_isOpen(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern ContextSettings sfRenderWindow_getSettings(IntPtr CPointer);
+        private static extern ContextSettings sfRenderWindow_getSettings(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderWindow_pollEvent(IntPtr CPointer, out Event Evt);
+        private static extern bool sfRenderWindow_pollEvent(IntPtr CPointer, out Event Evt);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderWindow_waitEvent(IntPtr CPointer, out Event Evt);
+        private static extern bool sfRenderWindow_waitEvent(IntPtr CPointer, out Event Evt);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfRenderWindow_getPosition(IntPtr CPointer);
+        private static extern Vector2i sfRenderWindow_getPosition(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setPosition(IntPtr CPointer, Vector2i position);
+        private static extern void sfRenderWindow_setPosition(IntPtr CPointer, Vector2i position);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2u sfRenderWindow_getSize(IntPtr CPointer);
+        private static extern Vector2u sfRenderWindow_getSize(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setSize(IntPtr CPointer, Vector2u size);
+        private static extern void sfRenderWindow_setSize(IntPtr CPointer, Vector2u size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setTitle(IntPtr CPointer, string title);
+        private static extern void sfRenderWindow_setTitle(IntPtr CPointer, string title);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setUnicodeTitle(IntPtr CPointer, IntPtr title);
+        private static extern void sfRenderWindow_setUnicodeTitle(IntPtr CPointer, IntPtr title);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern void sfRenderWindow_setIcon(IntPtr CPointer, uint Width, uint Height, byte* Pixels);
+        private unsafe static extern void sfRenderWindow_setIcon(IntPtr CPointer, uint Width, uint Height, byte* Pixels);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setVisible(IntPtr CPointer, bool visible);
+        private static extern void sfRenderWindow_setVisible(IntPtr CPointer, bool visible);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setVerticalSyncEnabled(IntPtr CPointer, bool Enable);
+        private static extern void sfRenderWindow_setVerticalSyncEnabled(IntPtr CPointer, bool Enable);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setMouseCursorVisible(IntPtr CPointer, bool visible);
+        private static extern void sfRenderWindow_setMouseCursorVisible(IntPtr CPointer, bool visible);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setMouseCursorGrabbed(IntPtr CPointer, bool grabbed);
+        private static extern void sfRenderWindow_setMouseCursorGrabbed(IntPtr CPointer, bool grabbed);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setMouseCursor(IntPtr window, IntPtr cursor);
+        private static extern void sfRenderWindow_setMouseCursor(IntPtr window, IntPtr cursor);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setKeyRepeatEnabled(IntPtr CPointer, bool Enable);
+        private static extern void sfRenderWindow_setKeyRepeatEnabled(IntPtr CPointer, bool Enable);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setFramerateLimit(IntPtr CPointer, uint Limit);
+        private static extern void sfRenderWindow_setFramerateLimit(IntPtr CPointer, uint Limit);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setJoystickThreshold(IntPtr CPointer, float Threshold);
+        private static extern void sfRenderWindow_setJoystickThreshold(IntPtr CPointer, float Threshold);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderWindow_setActive(IntPtr CPointer, bool Active);
+        private static extern bool sfRenderWindow_setActive(IntPtr CPointer, bool Active);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_requestFocus(IntPtr CPointer);
+        private static extern void sfRenderWindow_requestFocus(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderWindow_hasFocus(IntPtr CPointer);
+        private static extern bool sfRenderWindow_hasFocus(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_display(IntPtr CPointer);
+        private static extern void sfRenderWindow_display(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderWindow_getSystemHandle(IntPtr CPointer);
+        private static extern IntPtr sfRenderWindow_getSystemHandle(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_clear(IntPtr CPointer, Color ClearColor);
+        private static extern void sfRenderWindow_clear(IntPtr CPointer, Color ClearColor);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_setView(IntPtr CPointer, IntPtr View);
+        private static extern void sfRenderWindow_setView(IntPtr CPointer, IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderWindow_getView(IntPtr CPointer);
+        private static extern IntPtr sfRenderWindow_getView(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderWindow_getDefaultView(IntPtr CPointer);
+        private static extern IntPtr sfRenderWindow_getDefaultView(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntRect sfRenderWindow_getViewport(IntPtr CPointer, IntPtr TargetView);
+        private static extern IntRect sfRenderWindow_getViewport(IntPtr CPointer, IntPtr TargetView);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2f sfRenderWindow_mapPixelToCoords(IntPtr CPointer, Vector2i point, IntPtr View);
+        private static extern Vector2f sfRenderWindow_mapPixelToCoords(IntPtr CPointer, Vector2i point, IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfRenderWindow_mapCoordsToPixel(IntPtr CPointer, Vector2f point, IntPtr View);
+        private static extern Vector2i sfRenderWindow_mapCoordsToPixel(IntPtr CPointer, Vector2f point, IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern void sfRenderWindow_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, uint vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
+        private unsafe static extern void sfRenderWindow_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, uint vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_pushGLStates(IntPtr CPointer);
+        private static extern void sfRenderWindow_pushGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_popGLStates(IntPtr CPointer);
+        private static extern void sfRenderWindow_popGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_resetGLStates(IntPtr CPointer);
+        private static extern void sfRenderWindow_resetGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfRenderWindow_capture(IntPtr CPointer);
+        private static extern IntPtr sfRenderWindow_capture(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfMouse_getPositionRenderWindow(IntPtr CPointer);
+        private static extern Vector2i sfMouse_getPositionRenderWindow(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMouse_setPositionRenderWindow(Vector2i position, IntPtr CPointer);
+        private static extern void sfMouse_setPositionRenderWindow(Vector2i position, IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfTouch_getPositionRenderWindow(uint Finger, IntPtr RelativeTo);
+        private static extern Vector2i sfTouch_getPositionRenderWindow(uint Finger, IntPtr RelativeTo);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderWindow_saveGLStates(IntPtr CPointer);
+        private static extern bool sfRenderWindow_saveGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfRenderWindow_restoreGLStates(IntPtr CPointer);
+        private static extern bool sfRenderWindow_restoreGLStates(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfRenderWindow_getFrameTime(IntPtr CPointer);
+        private static extern uint sfRenderWindow_getFrameTime(IntPtr CPointer);
         #endregion
     }
 }

--- a/src/SFML.Graphics/Shader.cs
+++ b/src/SFML.Graphics/Shader.cs
@@ -741,118 +741,118 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfShader_createFromFile(string vertexShaderFilename, string geometryShaderFilename, string fragmentShaderFilename);
+        private static extern IntPtr sfShader_createFromFile(string vertexShaderFilename, string geometryShaderFilename, string fragmentShaderFilename);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfShader_createFromMemory(string vertexShader, string geometryShader, string fragmentShader);
+        private static extern IntPtr sfShader_createFromMemory(string vertexShader, string geometryShader, string fragmentShader);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfShader_createFromStream(IntPtr vertexShaderStream, IntPtr geometryShaderStream, IntPtr fragmentShaderStream);
+        private static extern IntPtr sfShader_createFromStream(IntPtr vertexShaderStream, IntPtr geometryShaderStream, IntPtr fragmentShaderStream);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_destroy(IntPtr shader);
+        private static extern void sfShader_destroy(IntPtr shader);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setFloatUniform(IntPtr shader, string name, float x);
+        private static extern void sfShader_setFloatUniform(IntPtr shader, string name, float x);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setVec2Uniform(IntPtr shader, string name, Glsl.Vec2 vector);
+        private static extern void sfShader_setVec2Uniform(IntPtr shader, string name, Glsl.Vec2 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setVec3Uniform(IntPtr shader, string name, Glsl.Vec3 vector);
+        private static extern void sfShader_setVec3Uniform(IntPtr shader, string name, Glsl.Vec3 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setVec4Uniform(IntPtr shader, string name, Glsl.Vec4 vector);
+        private static extern void sfShader_setVec4Uniform(IntPtr shader, string name, Glsl.Vec4 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setIntUniform(IntPtr shader, string name, int x);
+        private static extern void sfShader_setIntUniform(IntPtr shader, string name, int x);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setIvec2Uniform(IntPtr shader, string name, Glsl.Ivec2 vector);
+        private static extern void sfShader_setIvec2Uniform(IntPtr shader, string name, Glsl.Ivec2 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setIvec3Uniform(IntPtr shader, string name, Glsl.Ivec3 vector);
+        private static extern void sfShader_setIvec3Uniform(IntPtr shader, string name, Glsl.Ivec3 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setIvec4Uniform(IntPtr shader, string name, Glsl.Ivec4 vector);
+        private static extern void sfShader_setIvec4Uniform(IntPtr shader, string name, Glsl.Ivec4 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setBoolUniform(IntPtr shader, string name, bool x);
+        private static extern void sfShader_setBoolUniform(IntPtr shader, string name, bool x);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setBvec2Uniform(IntPtr shader, string name, Glsl.Bvec2 vector);
+        private static extern void sfShader_setBvec2Uniform(IntPtr shader, string name, Glsl.Bvec2 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setBvec3Uniform(IntPtr shader, string name, Glsl.Bvec3 vector);
+        private static extern void sfShader_setBvec3Uniform(IntPtr shader, string name, Glsl.Bvec3 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setBvec4Uniform(IntPtr shader, string name, Glsl.Bvec4 vector);
+        private static extern void sfShader_setBvec4Uniform(IntPtr shader, string name, Glsl.Bvec4 vector);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setMat3Uniform(IntPtr shader, string name, Glsl.Mat3 matrix);
+        private static extern void sfShader_setMat3Uniform(IntPtr shader, string name, Glsl.Mat3 matrix);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setMat4Uniform(IntPtr shader, string name, Glsl.Mat4 matrix);
+        private static extern void sfShader_setMat4Uniform(IntPtr shader, string name, Glsl.Mat4 matrix);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setTextureUniform(IntPtr shader, string name, IntPtr texture);
+        private static extern void sfShader_setTextureUniform(IntPtr shader, string name, IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_setCurrentTextureUniform(IntPtr shader, string name);
+        private static extern void sfShader_setCurrentTextureUniform(IntPtr shader, string name);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern unsafe void sfShader_setFloatUniformArray(IntPtr shader, string name, float* data, uint length);
+        private static extern unsafe void sfShader_setFloatUniformArray(IntPtr shader, string name, float* data, uint length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern unsafe void sfShader_setVec2UniformArray(IntPtr shader, string name, Glsl.Vec2* data, uint length);
+        private static extern unsafe void sfShader_setVec2UniformArray(IntPtr shader, string name, Glsl.Vec2* data, uint length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern unsafe void sfShader_setVec3UniformArray(IntPtr shader, string name, Glsl.Vec3* data, uint length);
+        private static extern unsafe void sfShader_setVec3UniformArray(IntPtr shader, string name, Glsl.Vec3* data, uint length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern unsafe void sfShader_setVec4UniformArray(IntPtr shader, string name, Glsl.Vec4* data, uint length);
+        private static extern unsafe void sfShader_setVec4UniformArray(IntPtr shader, string name, Glsl.Vec4* data, uint length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern unsafe void sfShader_setMat3UniformArray(IntPtr shader, string name, Glsl.Mat3* data, uint length);
+        private static extern unsafe void sfShader_setMat3UniformArray(IntPtr shader, string name, Glsl.Mat3* data, uint length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern unsafe void sfShader_setMat4UniformArray(IntPtr shader, string name, Glsl.Mat4* data, uint length);
+        private static extern unsafe void sfShader_setMat4UniformArray(IntPtr shader, string name, Glsl.Mat4* data, uint length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfShader_setFloatParameter(IntPtr shader, string name, float x);
+        private static extern void sfShader_setFloatParameter(IntPtr shader, string name, float x);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfShader_setFloat2Parameter(IntPtr shader, string name, float x, float y);
+        private static extern void sfShader_setFloat2Parameter(IntPtr shader, string name, float x, float y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfShader_setFloat3Parameter(IntPtr shader, string name, float x, float y, float z);
+        private static extern void sfShader_setFloat3Parameter(IntPtr shader, string name, float x, float y, float z);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfShader_setFloat4Parameter(IntPtr shader, string name, float x, float y, float z, float w);
+        private static extern void sfShader_setFloat4Parameter(IntPtr shader, string name, float x, float y, float z, float w);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfShader_setColorParameter(IntPtr shader, string name, Color color);
+        private static extern void sfShader_setColorParameter(IntPtr shader, string name, Color color);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfShader_setTransformParameter(IntPtr shader, string name, Transform transform);
+        private static extern void sfShader_setTransformParameter(IntPtr shader, string name, Transform transform);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfShader_setTextureParameter(IntPtr shader, string name, IntPtr texture);
+        private static extern void sfShader_setTextureParameter(IntPtr shader, string name, IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfShader_setCurrentTextureParameter(IntPtr shader, string name);
+        private static extern void sfShader_setCurrentTextureParameter(IntPtr shader, string name);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfShader_getNativeHandle(IntPtr shader);
+        private static extern uint sfShader_getNativeHandle(IntPtr shader);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShader_bind(IntPtr shader);
+        private static extern void sfShader_bind(IntPtr shader);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfShader_isAvailable();
+        private static extern bool sfShader_isAvailable();
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfShader_isGeometryAvailable();
+        private static extern bool sfShader_isGeometryAvailable();
         #endregion
     }
 }

--- a/src/SFML.Graphics/Shape.cs
+++ b/src/SFML.Graphics/Shape.cs
@@ -243,52 +243,52 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfShape_create(GetPointCountCallbackType getPointCount, GetPointCallbackType getPoint, IntPtr userData);
+        private static extern IntPtr sfShape_create(GetPointCountCallbackType getPointCount, GetPointCallbackType getPoint, IntPtr userData);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfShape_copy(IntPtr Shape);
+        private static extern IntPtr sfShape_copy(IntPtr Shape);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShape_destroy(IntPtr CPointer);
+        private static extern void sfShape_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShape_setTexture(IntPtr CPointer, IntPtr Texture, bool AdjustToNewSize);
+        private static extern void sfShape_setTexture(IntPtr CPointer, IntPtr Texture, bool AdjustToNewSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShape_setTextureRect(IntPtr CPointer, IntRect Rect);
+        private static extern void sfShape_setTextureRect(IntPtr CPointer, IntRect Rect);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntRect sfShape_getTextureRect(IntPtr CPointer);
+        private static extern IntRect sfShape_getTextureRect(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShape_setFillColor(IntPtr CPointer, Color Color);
+        private static extern void sfShape_setFillColor(IntPtr CPointer, Color Color);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Color sfShape_getFillColor(IntPtr CPointer);
+        private static extern Color sfShape_getFillColor(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShape_setOutlineColor(IntPtr CPointer, Color Color);
+        private static extern void sfShape_setOutlineColor(IntPtr CPointer, Color Color);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Color sfShape_getOutlineColor(IntPtr CPointer);
+        private static extern Color sfShape_getOutlineColor(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShape_setOutlineThickness(IntPtr CPointer, float Thickness);
+        private static extern void sfShape_setOutlineThickness(IntPtr CPointer, float Thickness);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfShape_getOutlineThickness(IntPtr CPointer);
+        private static extern float sfShape_getOutlineThickness(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern FloatRect sfShape_getLocalBounds(IntPtr CPointer);
+        private static extern FloatRect sfShape_getLocalBounds(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfShape_update(IntPtr CPointer);
+        private static extern void sfShape_update(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_drawShape(IntPtr CPointer, IntPtr Shape, ref RenderStates.MarshalData states);
+        private static extern void sfRenderWindow_drawShape(IntPtr CPointer, IntPtr Shape, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_drawShape(IntPtr CPointer, IntPtr Shape, ref RenderStates.MarshalData states);
+        private static extern void sfRenderTexture_drawShape(IntPtr CPointer, IntPtr Shape, ref RenderStates.MarshalData states);
         #endregion
     }
 }

--- a/src/SFML.Graphics/Sprite.cs
+++ b/src/SFML.Graphics/Sprite.cs
@@ -183,37 +183,37 @@ namespace SFML.Graphics
         #region Imports
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSprite_create();
+        private static extern IntPtr sfSprite_create();
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfSprite_copy(IntPtr Sprite);
+        private static extern IntPtr sfSprite_copy(IntPtr Sprite);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSprite_destroy(IntPtr CPointer);
+        private static extern void sfSprite_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSprite_setColor(IntPtr CPointer, Color Color);
+        private static extern void sfSprite_setColor(IntPtr CPointer, Color Color);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Color sfSprite_getColor(IntPtr CPointer);
+        private static extern Color sfSprite_getColor(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_drawSprite(IntPtr CPointer, IntPtr Sprite, ref RenderStates.MarshalData states);
+        private static extern void sfRenderWindow_drawSprite(IntPtr CPointer, IntPtr Sprite, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_drawSprite(IntPtr CPointer, IntPtr Sprite, ref RenderStates.MarshalData states);
+        private static extern void sfRenderTexture_drawSprite(IntPtr CPointer, IntPtr Sprite, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSprite_setTexture(IntPtr CPointer, IntPtr Texture, bool AdjustToNewSize);
+        private static extern void sfSprite_setTexture(IntPtr CPointer, IntPtr Texture, bool AdjustToNewSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSprite_setTextureRect(IntPtr CPointer, IntRect Rect);
+        private static extern void sfSprite_setTextureRect(IntPtr CPointer, IntRect Rect);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntRect sfSprite_getTextureRect(IntPtr CPointer);
+        private static extern IntRect sfSprite_getTextureRect(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern FloatRect sfSprite_getLocalBounds(IntPtr CPointer);
+        private static extern FloatRect sfSprite_getLocalBounds(IntPtr CPointer);
         #endregion
     }
 }

--- a/src/SFML.Graphics/Text.cs
+++ b/src/SFML.Graphics/Text.cs
@@ -370,88 +370,88 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfText_create();
+        private static extern IntPtr sfText_create();
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfText_copy(IntPtr Text);
+        private static extern IntPtr sfText_copy(IntPtr Text);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_destroy(IntPtr CPointer);
+        private static extern void sfText_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern void sfText_setColor(IntPtr CPointer, Color Color);
+        private static extern void sfText_setColor(IntPtr CPointer, Color Color);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setFillColor(IntPtr CPointer, Color Color);
+        private static extern void sfText_setFillColor(IntPtr CPointer, Color Color);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setOutlineColor(IntPtr CPointer, Color Color);
+        private static extern void sfText_setOutlineColor(IntPtr CPointer, Color Color);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setOutlineThickness(IntPtr CPointer, float thickness);
+        private static extern void sfText_setOutlineThickness(IntPtr CPointer, float thickness);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
-        static extern Color sfText_getColor(IntPtr CPointer);
+        private static extern Color sfText_getColor(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Color sfText_getFillColor(IntPtr CPointer);
+        private static extern Color sfText_getFillColor(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Color sfText_getOutlineColor(IntPtr CPointer);
+        private static extern Color sfText_getOutlineColor(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfText_getOutlineThickness(IntPtr CPointer);
+        private static extern float sfText_getOutlineThickness(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_drawText(IntPtr CPointer, IntPtr Text, ref RenderStates.MarshalData states);
+        private static extern void sfRenderWindow_drawText(IntPtr CPointer, IntPtr Text, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_drawText(IntPtr CPointer, IntPtr Text, ref RenderStates.MarshalData states);
+        private static extern void sfRenderTexture_drawText(IntPtr CPointer, IntPtr Text, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setUnicodeString(IntPtr CPointer, IntPtr Text);
+        private static extern void sfText_setUnicodeString(IntPtr CPointer, IntPtr Text);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setFont(IntPtr CPointer, IntPtr Font);
+        private static extern void sfText_setFont(IntPtr CPointer, IntPtr Font);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setCharacterSize(IntPtr CPointer, uint Size);
+        private static extern void sfText_setCharacterSize(IntPtr CPointer, uint Size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setLineSpacing(IntPtr CPointer, float spacingFactor);
+        private static extern void sfText_setLineSpacing(IntPtr CPointer, float spacingFactor);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setLetterSpacing(IntPtr CPointer, float spacingFactor);
+        private static extern void sfText_setLetterSpacing(IntPtr CPointer, float spacingFactor);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfText_setStyle(IntPtr CPointer, Styles Style);
+        private static extern void sfText_setStyle(IntPtr CPointer, Styles Style);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfText_getString(IntPtr CPointer);
+        private static extern IntPtr sfText_getString(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfText_getUnicodeString(IntPtr CPointer);
+        private static extern IntPtr sfText_getUnicodeString(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfText_getCharacterSize(IntPtr CPointer);
+        private static extern uint sfText_getCharacterSize(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfText_getLetterSpacing(IntPtr CPointer);
+        private static extern float sfText_getLetterSpacing(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfText_getLineSpacing(IntPtr CPointer);
+        private static extern float sfText_getLineSpacing(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Styles sfText_getStyle(IntPtr CPointer);
+        private static extern Styles sfText_getStyle(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern FloatRect sfText_getRect(IntPtr CPointer);
+        private static extern FloatRect sfText_getRect(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2f sfText_findCharacterPos(IntPtr CPointer, uint Index);
+        private static extern Vector2f sfText_findCharacterPos(IntPtr CPointer, uint Index);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern FloatRect sfText_getLocalBounds(IntPtr CPointer);
+        private static extern FloatRect sfText_getLocalBounds(IntPtr CPointer);
         #endregion
     }
 }

--- a/src/SFML.Graphics/Texture.cs
+++ b/src/SFML.Graphics/Texture.cs
@@ -481,82 +481,82 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfTexture_create(uint width, uint height);
+        private static extern IntPtr sfTexture_create(uint width, uint height);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfTexture_createFromFile(string filename, ref IntRect area);
+        private static extern IntPtr sfTexture_createFromFile(string filename, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfTexture_createFromStream(IntPtr stream, ref IntRect area);
+        private static extern IntPtr sfTexture_createFromStream(IntPtr stream, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfTexture_createFromImage(IntPtr image, ref IntRect area);
+        private static extern IntPtr sfTexture_createFromImage(IntPtr image, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfTexture_createFromMemory(IntPtr data, ulong size, ref IntRect area);
+        private static extern IntPtr sfTexture_createFromMemory(IntPtr data, ulong size, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfTexture_copy(IntPtr texture);
+        private static extern IntPtr sfTexture_copy(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_destroy(IntPtr texture);
+        private static extern void sfTexture_destroy(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2u sfTexture_getSize(IntPtr texture);
+        private static extern Vector2u sfTexture_getSize(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfTexture_copyToImage(IntPtr texture);
+        private static extern IntPtr sfTexture_copyToImage(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern void sfTexture_updateFromPixels(IntPtr texture, byte* pixels, uint width, uint height, uint x, uint y);
+        private unsafe static extern void sfTexture_updateFromPixels(IntPtr texture, byte* pixels, uint width, uint height, uint x, uint y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_updateFromTexture(IntPtr CPointer, IntPtr texture, uint x, uint y);
+        private static extern void sfTexture_updateFromTexture(IntPtr CPointer, IntPtr texture, uint x, uint y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_updateFromImage(IntPtr texture, IntPtr image, uint x, uint y);
+        private static extern void sfTexture_updateFromImage(IntPtr texture, IntPtr image, uint x, uint y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_updateFromWindow(IntPtr texture, IntPtr window, uint x, uint y);
+        private static extern void sfTexture_updateFromWindow(IntPtr texture, IntPtr window, uint x, uint y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_updateFromRenderWindow(IntPtr texture, IntPtr renderWindow, uint x, uint y);
+        private static extern void sfTexture_updateFromRenderWindow(IntPtr texture, IntPtr renderWindow, uint x, uint y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_bind(IntPtr texture);
+        private static extern void sfTexture_bind(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_setSmooth(IntPtr texture, bool smooth);
+        private static extern void sfTexture_setSmooth(IntPtr texture, bool smooth);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfTexture_isSmooth(IntPtr texture);
+        private static extern bool sfTexture_isSmooth(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_setSrgb(IntPtr texture, bool sRgb);
+        private static extern void sfTexture_setSrgb(IntPtr texture, bool sRgb);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfTexture_isSrgb(IntPtr texture);
+        private static extern bool sfTexture_isSrgb(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_setRepeated(IntPtr texture, bool repeated);
+        private static extern void sfTexture_setRepeated(IntPtr texture, bool repeated);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfTexture_isRepeated(IntPtr texture);
+        private static extern bool sfTexture_isRepeated(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfTexture_generateMipmap(IntPtr texture);
+        private static extern bool sfTexture_generateMipmap(IntPtr texture);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTexture_swap(IntPtr CPointer, IntPtr right);
+        private static extern void sfTexture_swap(IntPtr CPointer, IntPtr right);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfTexture_getNativeHandle(IntPtr shader);
+        private static extern uint sfTexture_getNativeHandle(IntPtr shader);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern FloatRect sfTexture_getTexCoords(IntPtr texture, IntRect rectangle);
+        private static extern FloatRect sfTexture_getTexCoords(IntPtr texture, IntRect rectangle);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfTexture_getMaximumSize();
+        private static extern uint sfTexture_getMaximumSize();
         #endregion
     }
 }

--- a/src/SFML.Graphics/Transform.cs
+++ b/src/SFML.Graphics/Transform.cs
@@ -346,34 +346,34 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Transform sfTransform_getInverse(ref Transform transform);
+        private static extern Transform sfTransform_getInverse(ref Transform transform);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2f sfTransform_transformPoint(ref Transform transform, Vector2f point);
+        private static extern Vector2f sfTransform_transformPoint(ref Transform transform, Vector2f point);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern FloatRect sfTransform_transformRect(ref Transform transform, FloatRect rectangle);
+        private static extern FloatRect sfTransform_transformRect(ref Transform transform, FloatRect rectangle);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTransform_combine(ref Transform transform, ref Transform other);
+        private static extern void sfTransform_combine(ref Transform transform, ref Transform other);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTransform_translate(ref Transform transform, float x, float y);
+        private static extern void sfTransform_translate(ref Transform transform, float x, float y);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTransform_rotate(ref Transform transform, float angle);
+        private static extern void sfTransform_rotate(ref Transform transform, float angle);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTransform_rotateWithCenter(ref Transform transform, float angle, float centerX, float centerY);
+        private static extern void sfTransform_rotateWithCenter(ref Transform transform, float angle, float centerX, float centerY);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTransform_scale(ref Transform transform, float scaleX, float scaleY);
+        private static extern void sfTransform_scale(ref Transform transform, float scaleX, float scaleY);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfTransform_scaleWithCenter(ref Transform transform, float scaleX, float scaleY, float centerX, float centerY);
+        private static extern void sfTransform_scaleWithCenter(ref Transform transform, float scaleX, float scaleY, float centerX, float centerY);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfTransform_equal(ref Transform left, ref Transform right);
+        private static extern bool sfTransform_equal(ref Transform left, ref Transform right);
         #endregion
     }
 }

--- a/src/SFML.Graphics/VertexArray.cs
+++ b/src/SFML.Graphics/VertexArray.cs
@@ -194,43 +194,43 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfVertexArray_create();
+        private static extern IntPtr sfVertexArray_create();
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfVertexArray_copy(IntPtr CPointer);
+        private static extern IntPtr sfVertexArray_copy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexArray_destroy(IntPtr CPointer);
+        private static extern void sfVertexArray_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfVertexArray_getVertexCount(IntPtr CPointer);
+        private static extern uint sfVertexArray_getVertexCount(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern unsafe Vertex* sfVertexArray_getVertex(IntPtr CPointer, uint index);
+        private static extern unsafe Vertex* sfVertexArray_getVertex(IntPtr CPointer, uint index);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexArray_clear(IntPtr CPointer);
+        private static extern void sfVertexArray_clear(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexArray_resize(IntPtr CPointer, uint vertexCount);
+        private static extern void sfVertexArray_resize(IntPtr CPointer, uint vertexCount);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexArray_append(IntPtr CPointer, Vertex vertex);
+        private static extern void sfVertexArray_append(IntPtr CPointer, Vertex vertex);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexArray_setPrimitiveType(IntPtr CPointer, PrimitiveType type);
+        private static extern void sfVertexArray_setPrimitiveType(IntPtr CPointer, PrimitiveType type);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern PrimitiveType sfVertexArray_getPrimitiveType(IntPtr CPointer);
+        private static extern PrimitiveType sfVertexArray_getPrimitiveType(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern FloatRect sfVertexArray_getBounds(IntPtr CPointer);
+        private static extern FloatRect sfVertexArray_getBounds(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_drawVertexArray(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
+        private static extern void sfRenderWindow_drawVertexArray(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_drawVertexArray(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
+        private static extern void sfRenderTexture_drawVertexArray(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
         #endregion
     }
 }

--- a/src/SFML.Graphics/VertexBuffer.cs
+++ b/src/SFML.Graphics/VertexBuffer.cs
@@ -277,49 +277,49 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfVertexBuffer_create(uint vertexCount, PrimitiveType type, UsageSpecifier usage);
+        private static extern IntPtr sfVertexBuffer_create(uint vertexCount, PrimitiveType type, UsageSpecifier usage);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfVertexBuffer_copy(IntPtr copy);
+        private static extern IntPtr sfVertexBuffer_copy(IntPtr copy);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexBuffer_destroy(IntPtr CPointer);
+        private static extern void sfVertexBuffer_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfVertexBuffer_getVertexCount(IntPtr CPointer);
+        private static extern uint sfVertexBuffer_getVertexCount(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern unsafe bool sfVertexBuffer_update(IntPtr CPointer, Vertex* vertices, uint vertexCount, uint offset);
+        private static extern unsafe bool sfVertexBuffer_update(IntPtr CPointer, Vertex* vertices, uint vertexCount, uint offset);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfVertexBuffer_updateFromVertexBuffer(IntPtr CPointer, IntPtr other);
+        private static extern bool sfVertexBuffer_updateFromVertexBuffer(IntPtr CPointer, IntPtr other);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexBuffer_swap(IntPtr CPointer, IntPtr other);
+        private static extern void sfVertexBuffer_swap(IntPtr CPointer, IntPtr other);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfVertexBuffer_getNativeHandle(IntPtr CPointer);
+        private static extern uint sfVertexBuffer_getNativeHandle(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexBuffer_setPrimitiveType(IntPtr CPointer, PrimitiveType primitiveType);
+        private static extern void sfVertexBuffer_setPrimitiveType(IntPtr CPointer, PrimitiveType primitiveType);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern PrimitiveType sfVertexBuffer_getPrimitiveType(IntPtr CPointer);
+        private static extern PrimitiveType sfVertexBuffer_getPrimitiveType(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfVertexBuffer_setUsage(IntPtr CPointer, UsageSpecifier usageType);
+        private static extern void sfVertexBuffer_setUsage(IntPtr CPointer, UsageSpecifier usageType);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern UsageSpecifier sfVertexBuffer_getUsage(IntPtr CPointer);
+        private static extern UsageSpecifier sfVertexBuffer_getUsage(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfVertexBuffer_isAvailable();
+        private static extern bool sfVertexBuffer_isAvailable();
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderWindow_drawVertexBuffer(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
+        private static extern void sfRenderWindow_drawVertexBuffer(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfRenderTexture_drawVertexBuffer(IntPtr CPointer, IntPtr VertexBuffer, ref RenderStates.MarshalData states);
+        private static extern void sfRenderTexture_drawVertexBuffer(IntPtr CPointer, IntPtr VertexBuffer, ref RenderStates.MarshalData states);
         #endregion
     }
 }

--- a/src/SFML.Graphics/View.cs
+++ b/src/SFML.Graphics/View.cs
@@ -196,52 +196,52 @@ namespace SFML.Graphics
 
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfView_create();
+        private static extern IntPtr sfView_create();
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfView_createFromRect(FloatRect Rect);
+        private static extern IntPtr sfView_createFromRect(FloatRect Rect);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfView_copy(IntPtr View);
+        private static extern IntPtr sfView_copy(IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_destroy(IntPtr View);
+        private static extern void sfView_destroy(IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_setCenter(IntPtr View, Vector2f center);
+        private static extern void sfView_setCenter(IntPtr View, Vector2f center);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_setSize(IntPtr View, Vector2f size);
+        private static extern void sfView_setSize(IntPtr View, Vector2f size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_setRotation(IntPtr View, float Angle);
+        private static extern void sfView_setRotation(IntPtr View, float Angle);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_setViewport(IntPtr View, FloatRect Viewport);
+        private static extern void sfView_setViewport(IntPtr View, FloatRect Viewport);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_reset(IntPtr View, FloatRect Rectangle);
+        private static extern void sfView_reset(IntPtr View, FloatRect Rectangle);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2f sfView_getCenter(IntPtr View);
+        private static extern Vector2f sfView_getCenter(IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2f sfView_getSize(IntPtr View);
+        private static extern Vector2f sfView_getSize(IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfView_getRotation(IntPtr View);
+        private static extern float sfView_getRotation(IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern FloatRect sfView_getViewport(IntPtr View);
+        private static extern FloatRect sfView_getViewport(IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_move(IntPtr View, Vector2f offset);
+        private static extern void sfView_move(IntPtr View, Vector2f offset);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_rotate(IntPtr View, float Angle);
+        private static extern void sfView_rotate(IntPtr View, float Angle);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfView_zoom(IntPtr View, float Factor);
+        private static extern void sfView_zoom(IntPtr View, float Factor);
         #endregion
     }
 }

--- a/src/SFML.System/Clock.cs
+++ b/src/SFML.System/Clock.cs
@@ -46,16 +46,16 @@ namespace SFML.System
 
         #region Imports
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfClock_create();
+        private static extern IntPtr sfClock_create();
 
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfClock_destroy(IntPtr CPointer);
+        private static extern void sfClock_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfClock_getElapsedTime(IntPtr Clock);
+        private static extern Time sfClock_getElapsedTime(IntPtr Clock);
 
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfClock_restart(IntPtr Clock);
+        private static extern Time sfClock_restart(IntPtr Clock);
         #endregion
     }
 }

--- a/src/SFML.System/Time.cs
+++ b/src/SFML.System/Time.cs
@@ -248,22 +248,22 @@ namespace SFML.System
 
         #region Imports
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfSeconds(float Amount);
+        private static extern Time sfSeconds(float Amount);
 
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfMilliseconds(int Amount);
+        private static extern Time sfMilliseconds(int Amount);
 
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Time sfMicroseconds(long Amount);
+        private static extern Time sfMicroseconds(long Amount);
 
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfTime_asSeconds(Time time);
+        private static extern float sfTime_asSeconds(Time time);
 
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern int sfTime_asMilliseconds(Time time);
+        private static extern int sfTime_asMilliseconds(Time time);
 
         [DllImport(CSFML.system, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern long sfTime_asMicroseconds(Time time);
+        private static extern long sfTime_asMicroseconds(Time time);
         #endregion
     }
 }

--- a/src/SFML.Window/Clipboard.cs
+++ b/src/SFML.Window/Clipboard.cs
@@ -49,9 +49,9 @@ namespace SFML.Window
         }
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfClipboard_getUnicodeString();
+        private static extern IntPtr sfClipboard_getUnicodeString();
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfClipboard_setUnicodeString(IntPtr ptr);
+        private static extern void sfClipboard_setUnicodeString(IntPtr ptr);
     }
 }

--- a/src/SFML.Window/Context.cs
+++ b/src/SFML.Window/Context.cs
@@ -90,16 +90,16 @@ namespace SFML.Window
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfContext_create();
+        private static extern IntPtr sfContext_create();
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfContext_destroy(IntPtr View);
+        private static extern void sfContext_destroy(IntPtr View);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfContext_setActive(IntPtr View, bool Active);
+        private static extern bool sfContext_setActive(IntPtr View, bool Active);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern ContextSettings sfContext_getSettings(IntPtr View);
+        private static extern ContextSettings sfContext_getSettings(IntPtr View);
         #endregion
     }
 }

--- a/src/SFML.Window/Cursor.cs
+++ b/src/SFML.Window/Cursor.cs
@@ -176,12 +176,12 @@ namespace SFML.Window
         }
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfCursor_createFromSystem(CursorType type);
+        private static extern IntPtr sfCursor_createFromSystem(CursorType type);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfCursor_createFromPixels(IntPtr pixels, Vector2u size, Vector2u hotspot);
+        private static extern IntPtr sfCursor_createFromPixels(IntPtr pixels, Vector2u size, Vector2u hotspot);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfCursor_destroy(IntPtr CPointer);
+        private static extern void sfCursor_destroy(IntPtr CPointer);
     }
 }

--- a/src/SFML.Window/Joystick.cs
+++ b/src/SFML.Window/Joystick.cs
@@ -186,25 +186,25 @@ namespace SFML.Window
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfJoystick_isConnected(uint joystick);
+        private static extern bool sfJoystick_isConnected(uint joystick);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfJoystick_getButtonCount(uint joystick);
+        private static extern uint sfJoystick_getButtonCount(uint joystick);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfJoystick_hasAxis(uint joystick, Axis axis);
+        private static extern bool sfJoystick_hasAxis(uint joystick, Axis axis);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfJoystick_isButtonPressed(uint joystick, uint button);
+        private static extern bool sfJoystick_isButtonPressed(uint joystick, uint button);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern float sfJoystick_getAxisPosition(uint joystick, Axis axis);
+        private static extern float sfJoystick_getAxisPosition(uint joystick, Axis axis);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfJoystick_update();
+        private static extern void sfJoystick_update();
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IdentificationMarshalData sfJoystick_getIdentification(uint joystick);
+        private static extern IdentificationMarshalData sfJoystick_getIdentification(uint joystick);
         #endregion
     }
 }

--- a/src/SFML.Window/Keyboard.cs
+++ b/src/SFML.Window/Keyboard.cs
@@ -271,10 +271,10 @@ namespace SFML.Window
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfKeyboard_isKeyPressed(Key Key);
+        private static extern bool sfKeyboard_isKeyPressed(Key Key);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfKeyboard_setVirtualKeyboardVisible(bool visible);
+        private static extern void sfKeyboard_setVirtualKeyboardVisible(bool visible);
         #endregion
     }
 }

--- a/src/SFML.Window/Mouse.cs
+++ b/src/SFML.Window/Mouse.cs
@@ -134,13 +134,13 @@ namespace SFML.Window
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfMouse_isButtonPressed(Button button);
+        private static extern bool sfMouse_isButtonPressed(Button button);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfMouse_getPosition(IntPtr relativeTo);
+        private static extern Vector2i sfMouse_getPosition(IntPtr relativeTo);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMouse_setPosition(Vector2i position, IntPtr relativeTo);
+        private static extern void sfMouse_setPosition(Vector2i position, IntPtr relativeTo);
         #endregion
     }
 }

--- a/src/SFML.Window/Sensor.cs
+++ b/src/SFML.Window/Sensor.cs
@@ -78,13 +78,13 @@ namespace SFML.Window
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfSensor_isAvailable(Type Sensor);
+        private static extern bool sfSensor_isAvailable(Type Sensor);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfSensor_setEnabled(Type Sensor, bool Enabled);
+        private static extern void sfSensor_setEnabled(Type Sensor, bool Enabled);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector3f sfSensor_getValue(Type Sensor);
+        private static extern Vector3f sfSensor_getValue(Type Sensor);
         #endregion
     }
 }

--- a/src/SFML.Window/Touch.cs
+++ b/src/SFML.Window/Touch.cs
@@ -59,10 +59,10 @@ namespace SFML.Window
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfTouch_isDown(uint Finger);
+        private static extern bool sfTouch_isDown(uint Finger);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfTouch_getPosition(uint Finger, IntPtr RelativeTo);
+        private static extern Vector2i sfTouch_getPosition(uint Finger, IntPtr RelativeTo);
         #endregion
     }
 }

--- a/src/SFML.Window/VideoMode.cs
+++ b/src/SFML.Window/VideoMode.cs
@@ -111,13 +111,13 @@ namespace SFML.Window
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern VideoMode sfVideoMode_getDesktopMode();
+        private static extern VideoMode sfVideoMode_getDesktopMode();
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern VideoMode* sfVideoMode_getFullscreenModes(out uint Count);
+        private unsafe static extern VideoMode* sfVideoMode_getFullscreenModes(out uint Count);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfVideoMode_isValid(VideoMode Mode);
+        private static extern bool sfVideoMode_isValid(VideoMode Mode);
         #endregion
     }
 }

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -781,103 +781,103 @@ namespace SFML.Window
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfWindow_create(VideoMode Mode, string Title, Styles Style, ref ContextSettings Params);
+        private static extern IntPtr sfWindow_create(VideoMode Mode, string Title, Styles Style, ref ContextSettings Params);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfWindow_createUnicode(VideoMode Mode, IntPtr Title, Styles Style, ref ContextSettings Params);
+        private static extern IntPtr sfWindow_createUnicode(VideoMode Mode, IntPtr Title, Styles Style, ref ContextSettings Params);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfWindow_createFromHandle(IntPtr Handle, ref ContextSettings Params);
+        private static extern IntPtr sfWindow_createFromHandle(IntPtr Handle, ref ContextSettings Params);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_destroy(IntPtr CPointer);
+        private static extern void sfWindow_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfWindow_isOpen(IntPtr CPointer);
+        private static extern bool sfWindow_isOpen(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_close(IntPtr CPointer);
+        private static extern void sfWindow_close(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfWindow_pollEvent(IntPtr CPointer, out Event Evt);
+        private static extern bool sfWindow_pollEvent(IntPtr CPointer, out Event Evt);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfWindow_waitEvent(IntPtr CPointer, out Event Evt);
+        private static extern bool sfWindow_waitEvent(IntPtr CPointer, out Event Evt);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_display(IntPtr CPointer);
+        private static extern void sfWindow_display(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern ContextSettings sfWindow_getSettings(IntPtr CPointer);
+        private static extern ContextSettings sfWindow_getSettings(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfWindow_getPosition(IntPtr CPointer);
+        private static extern Vector2i sfWindow_getPosition(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setPosition(IntPtr CPointer, Vector2i position);
+        private static extern void sfWindow_setPosition(IntPtr CPointer, Vector2i position);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2u sfWindow_getSize(IntPtr CPointer);
+        private static extern Vector2u sfWindow_getSize(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setSize(IntPtr CPointer, Vector2u size);
+        private static extern void sfWindow_setSize(IntPtr CPointer, Vector2u size);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setTitle(IntPtr CPointer, string title);
+        private static extern void sfWindow_setTitle(IntPtr CPointer, string title);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setUnicodeTitle(IntPtr CPointer, IntPtr title);
+        private static extern void sfWindow_setUnicodeTitle(IntPtr CPointer, IntPtr title);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        unsafe static extern void sfWindow_setIcon(IntPtr CPointer, uint Width, uint Height, byte* Pixels);
+        private unsafe static extern void sfWindow_setIcon(IntPtr CPointer, uint Width, uint Height, byte* Pixels);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setVisible(IntPtr CPointer, bool visible);
+        private static extern void sfWindow_setVisible(IntPtr CPointer, bool visible);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setMouseCursorVisible(IntPtr CPointer, bool Show);
+        private static extern void sfWindow_setMouseCursorVisible(IntPtr CPointer, bool Show);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setMouseCursorGrabbed(IntPtr CPointer, bool grabbed);
+        private static extern void sfWindow_setMouseCursorGrabbed(IntPtr CPointer, bool grabbed);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setMouseCursor(IntPtr CPointer, IntPtr cursor);
+        private static extern void sfWindow_setMouseCursor(IntPtr CPointer, IntPtr cursor);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setVerticalSyncEnabled(IntPtr CPointer, bool Enable);
+        private static extern void sfWindow_setVerticalSyncEnabled(IntPtr CPointer, bool Enable);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setKeyRepeatEnabled(IntPtr CPointer, bool Enable);
+        private static extern void sfWindow_setKeyRepeatEnabled(IntPtr CPointer, bool Enable);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfWindow_setActive(IntPtr CPointer, bool Active);
+        private static extern bool sfWindow_setActive(IntPtr CPointer, bool Active);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setFramerateLimit(IntPtr CPointer, uint Limit);
+        private static extern void sfWindow_setFramerateLimit(IntPtr CPointer, uint Limit);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern uint sfWindow_getFrameTime(IntPtr CPointer);
+        private static extern uint sfWindow_getFrameTime(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_setJoystickThreshold(IntPtr CPointer, float Threshold);
+        private static extern void sfWindow_setJoystickThreshold(IntPtr CPointer, float Threshold);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern IntPtr sfWindow_getSystemHandle(IntPtr CPointer);
+        private static extern IntPtr sfWindow_getSystemHandle(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfWindow_requestFocus(IntPtr CPointer);
+        private static extern void sfWindow_requestFocus(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern bool sfWindow_hasFocus(IntPtr CPointer);
+        private static extern bool sfWindow_hasFocus(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfMouse_getPosition(IntPtr CPointer);
+        private static extern Vector2i sfMouse_getPosition(IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern void sfMouse_setPosition(Vector2i position, IntPtr CPointer);
+        private static extern void sfMouse_setPosition(Vector2i position, IntPtr CPointer);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        static extern Vector2i sfTouch_getPosition(uint Finger, IntPtr RelativeTo);
+        private static extern Vector2i sfTouch_getPosition(uint Finger, IntPtr RelativeTo);
         #endregion
     }
 }


### PR DESCRIPTION
This PR is a refactor across SFML.Net that resolves all 457 warnings of missing access modifiers (IDE0040). My original motive to do this was due to missing access modifiers being part of bug #207. 

All 457 warnings are missing access modifiers for the pinvoke methods and so this PR adds `private` modifier to all pinvoke methods as thats the default when not specified.

Some diffs show entire source files being changed which is a result of some source files having mixed file endings and I've set it to whatever I found to be the common in the relevant project.

In terms of testing, I've done some basic feature tests such as shape rendering and playing music. As this is a sweeping change across the entire project, **I encourage some thorough code reviewing and understand if this PR gets put on hold for a future major version change.**

This wasn't just a find and replace effort and was an opportunity to also check over every PInvoke method and their CSFML counterparts, which has uncovered other issues of various severity that I'll raise separately after creating this PR.