### PR TITLE
Fixed Several API disparities

### DIFF
--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -395,10 +395,10 @@ namespace SFML.Graphics
         private static extern Vector2u sfImage_getSize(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern uint sfImage_flipHorizontally(IntPtr CPointer);
+        private static extern void sfImage_flipHorizontally(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern uint sfImage_flipVertically(IntPtr CPointer);
+        private static extern void sfImage_flipVertically(IntPtr CPointer);
         #endregion
     }
 }

--- a/src/SFML.Graphics/Shader.cs
+++ b/src/SFML.Graphics/Shader.cs
@@ -201,7 +201,17 @@ namespace SFML.Graphics
         {
             sfShader_setIntUniform(CPointer, name, x);
         }
-
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Specify value for <c>color</c> uniform
+        /// </summary>
+        /// <param name="name">Name of the uniform variable in GLSL</param>
+        /// <param name="color">Value of the vec4 vector</param>
+        ////////////////////////////////////////////////////////////
+        public void SetUniform(string name, Color color)
+        {
+            sfShader_setColorUniform(CPointer, name, color);
+        }
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Specify value for <c>ivec2</c> uniform
@@ -766,6 +776,8 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfShader_setIntUniform(IntPtr shader, string name, int x);
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfShader_setColorUniform(IntPtr shader, string name, Color color);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfShader_setIvec2Uniform(IntPtr shader, string name, Glsl.Ivec2 vector);

--- a/src/SFML.Graphics/VertexBuffer.cs
+++ b/src/SFML.Graphics/VertexBuffer.cs
@@ -123,6 +123,20 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Bind a vertex buffer for rendering.
+        /// 
+        /// This function is not part of the graphics API, it mustn't
+        /// be used when drawing SFML entities. It must be used only if
+        /// you mix VertexBuffer with OpenGL code.
+        /// </summary>
+        /// <param name="vertexBuffer">The vertex buffer to bind, can be null to use no vertex buffer</param>
+        ////////////////////////////////////////////////////////////
+        public static void Bind(VertexBuffer vertexBuffer)
+        {
+            sfVertexBuffer_bind(vertexBuffer?.CPointer ?? IntPtr.Zero);
+        }
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Update a part of the buffer from an array of vertices
         /// offset is specified as the number of vertices to skip
         /// from the beginning of the buffer.
@@ -311,7 +325,8 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern UsageSpecifier sfVertexBuffer_getUsage(IntPtr CPointer);
-
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfVertexBuffer_bind(IntPtr CPointer);
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfVertexBuffer_isAvailable();
 


### PR DESCRIPTION
Mentioned in #210: CSFML specifies return type of `sfImage_flipVertically` and `sfImage_flipHorizontally` of type ``void`` but C# invocation method did not match this.

Mentioned in #215: CSFML defines 2 functions that were not exposed: `sfShader_setUniform(.. sfColor)` and `sfVertexBuffer_bind`. The former is now exposed as ``SetUniform(string, color)``. The latter is now bound to a static member of `VertexBuffer` named `Bind(VertexBuffer)`