### PR TITLE
Updated GLSL.cs

### DIFF
--- a/src/SFML.Graphics/Glsl.cs
+++ b/src/SFML.Graphics/Glsl.cs
@@ -118,9 +118,11 @@ namespace SFML.Graphics.Glsl
         }
 
         /// <summary>Horizontal component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool X;
 
         /// <summary>Vertical component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool Y;
     }
     #endregion
@@ -235,12 +237,15 @@ namespace SFML.Graphics.Glsl
         }
 
         /// <summary>Horizontal component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool X;
 
         /// <summary>Vertical component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool Y;
 
         /// <summary>Depth component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool Z;
     }
     #endregion
@@ -375,15 +380,19 @@ namespace SFML.Graphics.Glsl
         }
 
         /// <summary>Horizontal component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool X;
 
         /// <summary>Vertical component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool Y;
 
         /// <summary>Depth component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool Z;
 
         /// <summary>Projective/Homogenous component of the vector</summary>
+        [MarshalAs(UnmanagedType.Bool)]
         public bool W;
     }
     #endregion


### PR DESCRIPTION
Mentioned in #213: CSFML specifies defines ``sfBool`` as ``int`` which is a 4-byte long integer. Until decided, I have marked the fields to be marshalled as ``Bool`` which seems to fix the issue. This will probably be to be fixed later. but it works for now on 64x OS's