### PR TITLE
Update CSFML Dependency to 2.5.1

### DIFF
--- a/SFML.NuGet.props
+++ b/SFML.NuGet.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <Authors>Laurent Gomila</Authors>
     <PackageTags>sfml sfml.net</PackageTags>
     <Copyright>Copyright © Laurent Gomila</Copyright>


### PR DESCRIPTION
Fixes #223

Discovered CSFML 2.5.0 is missing a method export on the `Texture` class. 2.5.1 has the missing method.

This PR updates the `Version` property in the root props file which is used here to reference the same versioned CSFML package:

https://github.com/SFML/SFML.Net/blob/f678eb2cf1eadf1a4f95cf1febd1da1d78ddcd7f/SFML.Module.props#L20

Thanks!