### PR TITLE
Remove unnecessary dependencies for the Audio module

### DIFF
--- a/src/SFML.Audio/SFML.Audio.csproj
+++ b/src/SFML.Audio/SFML.Audio.csproj
@@ -8,9 +8,7 @@
   <Import Project="..\..\SFML.Module.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\SFML.Graphics\SFML.Graphics.csproj" />
     <ProjectReference Include="..\SFML.System\SFML.System.csproj" />
-    <ProjectReference Include="..\SFML.Window\SFML.Window.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Not sure why the Graphics and Window module were set up as dependency for the Audio module, but I've removed them now.