### PR TITLE
Enumeration for events

### DIFF
--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -390,7 +390,7 @@ namespace SFML.Window
         ////////////////////////////////////////////////////////////
         public IEnumerable<Event> EnumerateEvents(bool dispatchEvent=true)
         {
-            while (PollEvent(out var e))
+            while (PollEvent(out Event e))
             {
                 if(dispatchEvent)
                 {

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
@@ -375,10 +376,27 @@ namespace SFML.Window
         ////////////////////////////////////////////////////////////
         public void DispatchEvents()
         {
-            Event e;
-            while (PollEvent(out e))
+            while (PollEvent(out Event e))
             {
                 CallEventHandler(e);
+            }
+        }
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Enumerates over each pending event
+        /// </summary>
+        /// <param name="dispatchEvent">if true, calls the event handler for the event as well</param>
+        /// <returns>The enumeration of events</returns>
+        ////////////////////////////////////////////////////////////
+        public IEnumerable<Event> EnumerateEvents(bool dispatchEvent=true)
+        {
+            while (PollEvent(out var e))
+            {
+                if(dispatchEvent)
+                {
+                    CallEventHandler(e);
+                }
+                yield return e;
             }
         }
 
@@ -636,7 +654,7 @@ namespace SFML.Window
 
                     break;
 
-// Disable CS0618 (Obselete Warning).  This Event will be removed in SFML.NET 3.0, but should remain supported until then.
+                // Disable CS0618 (Obselete Warning).  This Event will be removed in SFML.NET 3.0, but should remain supported until then.
 #pragma warning disable CS0618
                 case EventType.MouseWheelMoved:
                     if (MouseWheelMoved != null)
@@ -645,7 +663,7 @@ namespace SFML.Window
                     }
 
                     break;
-// restore CS0618
+                // restore CS0618
 #pragma warning restore CS0618
 
                 case EventType.MouseWheelScrolled:


### PR DESCRIPTION
## What this PR does

Adds a method `EnumerateEvents` to window. This returns an enumeration of "raw" events (that is, `IEnumerable<Event>`), which can be used in a `foreach` block of C#. It also includes a bool parameter to dispatch the events as well.

```csharp
public IEnumerable<Event> EnumerateEvents(bool dispatchEvent=true) {...}
```

This allows a C# developer to handle the raw events similar to how it is done in C++ if they like to. I feel it can be a good alternative to using events, since the `PollEvent()` is protected.

## File(s) changed
Only one file
> src/SFML.Window/Window.cs

## Usage example

```csharp
// If the user wishes to handle events themselves
foreach(Event e in window.EnumerateEvents(false))
{
  if(e.Type==EventType.KeyPressed || e.Type==EventType.KeyReleased)
  {
    var key = e.Key;
    ... // handle event 
  }
}
```


```csharp
// If the user wishes to dispatch using C# events, and describe/debug the events
foreach(Event e in window.EnumerateEvents(true))
{
  Console.WriteLine(e.Type);
}
```