### PR TITLE
Unify all size_t arguments to use uint

### DIFF
--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -390,7 +390,7 @@ namespace SFML.Audio
         private unsafe static extern IntPtr sfMusic_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfMusic_createFromMemory(IntPtr data, ulong size);
+        private static extern IntPtr sfMusic_createFromMemory(IntPtr data, uint size);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfMusic_destroy(IntPtr MusicStream);

--- a/src/SFML.Audio/SoundBuffer.cs
+++ b/src/SFML.Audio/SoundBuffer.cs
@@ -224,7 +224,7 @@ namespace SFML.Audio
         private unsafe static extern IntPtr sfSoundBuffer_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern IntPtr sfSoundBuffer_createFromMemory(IntPtr data, ulong size);
+        private unsafe static extern IntPtr sfSoundBuffer_createFromMemory(IntPtr data, uint size);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private unsafe static extern IntPtr sfSoundBuffer_createFromSamples(short* Samples, ulong SampleCount, uint ChannelsCount, uint SampleRate);

--- a/src/SFML.Graphics/Font.cs
+++ b/src/SFML.Graphics/Font.cs
@@ -230,7 +230,7 @@ namespace SFML.Graphics
         private static extern IntPtr sfFont_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfFont_createFromMemory(IntPtr data, ulong size);
+        private static extern IntPtr sfFont_createFromMemory(IntPtr data, uint size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfFont_copy(IntPtr Font);

--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -365,7 +365,7 @@ namespace SFML.Graphics
         private unsafe static extern IntPtr sfImage_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern IntPtr sfImage_createFromMemory(IntPtr data, ulong size);
+        private unsafe static extern IntPtr sfImage_createFromMemory(IntPtr data, uint size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfImage_copy(IntPtr Image);

--- a/src/SFML.Graphics/Texture.cs
+++ b/src/SFML.Graphics/Texture.cs
@@ -493,7 +493,7 @@ namespace SFML.Graphics
         private static extern IntPtr sfTexture_createFromImage(IntPtr image, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfTexture_createFromMemory(IntPtr data, ulong size, ref IntRect area);
+        private static extern IntPtr sfTexture_createFromMemory(IntPtr data, uint size, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfTexture_copy(IntPtr texture);


### PR DESCRIPTION
Somewhat addresses #212
* Updated to use `uint` consistently where CSFML is expecting `size_t`
* `UIntPtr` is the most correct type for `size_t`, but switching to it would result in breaking changes for end users
* uint should be replaced with `nuint` when moving to .NET 5+