### PR TITLE
Unify all size_t arguments to use UIntPtr

### DIFF
--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -4,6 +4,8 @@ using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Audio
 {
     ////////////////////////////////////////////////////////////
@@ -59,7 +61,7 @@ namespace SFML.Audio
             GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
             try
             {
-                CPointer = sfMusic_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
+                CPointer = sfMusic_createFromMemory(pin.AddrOfPinnedObject(), (SIZE_T)bytes.Length);
             }
             finally
             {
@@ -390,7 +392,7 @@ namespace SFML.Audio
         private unsafe static extern IntPtr sfMusic_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfMusic_createFromMemory(IntPtr data, ulong size);
+        private static extern IntPtr sfMusic_createFromMemory(IntPtr data, SIZE_T size);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfMusic_destroy(IntPtr MusicStream);

--- a/src/SFML.Audio/SoundBuffer.cs
+++ b/src/SFML.Audio/SoundBuffer.cs
@@ -4,6 +4,8 @@ using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Audio
 {
     ////////////////////////////////////////////////////////////
@@ -75,7 +77,7 @@ namespace SFML.Audio
             GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
             try
             {
-                CPointer = sfSoundBuffer_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
+                CPointer = sfSoundBuffer_createFromMemory(pin.AddrOfPinnedObject(), (SIZE_T)bytes.Length);
             }
             finally
             {
@@ -224,7 +226,7 @@ namespace SFML.Audio
         private unsafe static extern IntPtr sfSoundBuffer_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern IntPtr sfSoundBuffer_createFromMemory(IntPtr data, ulong size);
+        private unsafe static extern IntPtr sfSoundBuffer_createFromMemory(IntPtr data, SIZE_T size);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private unsafe static extern IntPtr sfSoundBuffer_createFromSamples(short* Samples, ulong SampleCount, uint ChannelsCount, uint SampleRate);

--- a/src/SFML.Audio/SoundRecorder.cs
+++ b/src/SFML.Audio/SoundRecorder.cs
@@ -3,6 +3,8 @@ using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Audio
 {
     ////////////////////////////////////////////////////////////
@@ -271,9 +273,9 @@ namespace SFML.Audio
         /// <param name="userData">User data -- unused</param>
         /// <returns>False to stop recording audio data, true to continue</returns>
         ////////////////////////////////////////////////////////////
-        private bool ProcessSamples(IntPtr samples, uint nbSamples, IntPtr userData)
+        private bool ProcessSamples(IntPtr samples, SIZE_T nbSamples, IntPtr userData)
         {
-            short[] samplesArray = new short[nbSamples];
+            short[] samplesArray = new short[(int)nbSamples];
             Marshal.Copy(samples, samplesArray, 0, samplesArray.Length);
 
             return OnProcessSamples(samplesArray);
@@ -283,7 +285,7 @@ namespace SFML.Audio
         private delegate bool StartCallback();
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate bool ProcessCallback(IntPtr samples, uint nbSamples, IntPtr userData);
+        private delegate bool ProcessCallback(IntPtr samples, SIZE_T nbSamples, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void StopCallback();

--- a/src/SFML.Graphics/Font.cs
+++ b/src/SFML.Graphics/Font.cs
@@ -6,6 +6,8 @@ using System.Security;
 using SFML.System;
 using SFML.Window;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
@@ -41,8 +43,10 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public Font(Stream stream) : base(IntPtr.Zero)
         {
-            myStream = new StreamAdaptor(stream);
-            CPointer = sfFont_createFromStream(myStream.InputStreamPtr);
+            using (var adaptor = new StreamAdaptor(stream))
+            {
+                CPointer = sfFont_createFromStream(adaptor.InputStreamPtr);
+            }
 
             if (CPointer == IntPtr.Zero)
             {
@@ -57,7 +61,23 @@ namespace SFML.Graphics
         /// <param name="bytes">Byte array containing the file contents</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Font(byte[] bytes) : this(new MemoryStream(bytes)) { }
+        public Font(byte[] bytes) :
+            base(IntPtr.Zero)
+        {
+            GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+            try
+            {
+                CPointer = sfFont_createFromMemory(pin.AddrOfPinnedObject(), (SIZE_T)bytes.Length);
+            }
+            finally
+            {
+                pin.Free();
+            }
+            if (CPointer == IntPtr.Zero)
+            {
+                throw new LoadingFailedException("font");
+            }
+        }
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -230,7 +250,7 @@ namespace SFML.Graphics
         private static extern IntPtr sfFont_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfFont_createFromMemory(IntPtr data, ulong size);
+        private static extern IntPtr sfFont_createFromMemory(IntPtr data, SIZE_T size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfFont_copy(IntPtr Font);

--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -4,6 +4,8 @@ using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
@@ -90,7 +92,7 @@ namespace SFML.Graphics
             GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
             try
             {
-                CPointer = sfImage_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
+                CPointer = sfImage_createFromMemory(pin.AddrOfPinnedObject(), (SIZE_T)bytes.Length);
             }
             finally
             {
@@ -365,7 +367,7 @@ namespace SFML.Graphics
         private unsafe static extern IntPtr sfImage_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern IntPtr sfImage_createFromMemory(IntPtr data, ulong size);
+        private unsafe static extern IntPtr sfImage_createFromMemory(IntPtr data, SIZE_T size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfImage_copy(IntPtr Image);

--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -4,6 +4,8 @@ using System.Security;
 using SFML.System;
 using SFML.Window;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
@@ -400,7 +402,7 @@ namespace SFML.Graphics
             {
                 fixed (Vertex* vertexPtr = vertices)
                 {
-                    sfRenderTexture_drawPrimitives(CPointer, vertexPtr + start, count, type, ref marshaledStates);
+                    sfRenderTexture_drawPrimitives(CPointer, vertexPtr + start, (SIZE_T)count, type, ref marshaledStates);
                 }
             }
         }
@@ -593,7 +595,7 @@ namespace SFML.Graphics
         private static extern bool sfRenderTexture_generateMipmap(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern void sfRenderTexture_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, uint vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
+        private unsafe static extern void sfRenderTexture_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, SIZE_T vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfRenderTexture_pushGLStates(IntPtr CPointer);

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -5,6 +5,8 @@ using System.Text;
 using SFML.System;
 using SFML.Window;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
@@ -578,7 +580,7 @@ namespace SFML.Graphics
             {
                 fixed (Vertex* vertexPtr = vertices)
                 {
-                    sfRenderWindow_drawPrimitives(CPointer, vertexPtr + start, count, type, ref marshaledStates);
+                    sfRenderWindow_drawPrimitives(CPointer, vertexPtr + start, (SIZE_T)count, type, ref marshaledStates);
                 }
             }
         }
@@ -903,7 +905,7 @@ namespace SFML.Graphics
         private static extern Vector2i sfRenderWindow_mapCoordsToPixel(IntPtr CPointer, Vector2f point, IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern void sfRenderWindow_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, uint vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
+        private unsafe static extern void sfRenderWindow_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, SIZE_T vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfRenderWindow_pushGLStates(IntPtr CPointer);

--- a/src/SFML.Graphics/Shader.cs
+++ b/src/SFML.Graphics/Shader.cs
@@ -6,6 +6,8 @@ using System.Security;
 using SFML.System;
 using SFML.Window;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
@@ -406,7 +408,7 @@ namespace SFML.Graphics
         {
             fixed (float* data = array)
             {
-                sfShader_setFloatUniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setFloatUniformArray(CPointer, name, data, (SIZE_T)array.Length);
             }
         }
 
@@ -421,7 +423,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Vec2* data = array)
             {
-                sfShader_setVec2UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setVec2UniformArray(CPointer, name, data, (SIZE_T)array.Length);
             }
         }
 
@@ -436,7 +438,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Vec3* data = array)
             {
-                sfShader_setVec3UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setVec3UniformArray(CPointer, name, data, (SIZE_T)array.Length);
             }
         }
 
@@ -451,7 +453,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Vec4* data = array)
             {
-                sfShader_setVec4UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setVec4UniformArray(CPointer, name, data, (SIZE_T)array.Length);
             }
         }
 
@@ -466,7 +468,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Mat3* data = array)
             {
-                sfShader_setMat3UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setMat3UniformArray(CPointer, name, data, (SIZE_T)array.Length);
             }
         }
 
@@ -481,7 +483,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Mat4* data = array)
             {
-                sfShader_setMat4UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setMat4UniformArray(CPointer, name, data, (SIZE_T)array.Length);
             }
         }
 
@@ -816,22 +818,22 @@ namespace SFML.Graphics
         private static extern void sfShader_setCurrentTextureUniform(IntPtr shader, string name);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setFloatUniformArray(IntPtr shader, string name, float* data, uint length);
+        private static extern unsafe void sfShader_setFloatUniformArray(IntPtr shader, string name, float* data, SIZE_T length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setVec2UniformArray(IntPtr shader, string name, Glsl.Vec2* data, uint length);
+        private static extern unsafe void sfShader_setVec2UniformArray(IntPtr shader, string name, Glsl.Vec2* data, SIZE_T length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setVec3UniformArray(IntPtr shader, string name, Glsl.Vec3* data, uint length);
+        private static extern unsafe void sfShader_setVec3UniformArray(IntPtr shader, string name, Glsl.Vec3* data, SIZE_T length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setVec4UniformArray(IntPtr shader, string name, Glsl.Vec4* data, uint length);
+        private static extern unsafe void sfShader_setVec4UniformArray(IntPtr shader, string name, Glsl.Vec4* data, SIZE_T length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setMat3UniformArray(IntPtr shader, string name, Glsl.Mat3* data, uint length);
+        private static extern unsafe void sfShader_setMat3UniformArray(IntPtr shader, string name, Glsl.Mat3* data, SIZE_T length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setMat4UniformArray(IntPtr shader, string name, Glsl.Mat4* data, uint length);
+        private static extern unsafe void sfShader_setMat4UniformArray(IntPtr shader, string name, Glsl.Mat4* data, SIZE_T length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
         private static extern void sfShader_setFloatParameter(IntPtr shader, string name, float x);

--- a/src/SFML.Graphics/Text.cs
+++ b/src/SFML.Graphics/Text.cs
@@ -4,6 +4,8 @@ using System.Security;
 using System.Text;
 using SFML.System;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
@@ -276,7 +278,7 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public Vector2f FindCharacterPos(uint index)
         {
-            return sfText_findCharacterPos(CPointer, index);
+            return sfText_findCharacterPos(CPointer, (SIZE_T)index);
         }
 
         ////////////////////////////////////////////////////////////
@@ -448,7 +450,7 @@ namespace SFML.Graphics
         private static extern FloatRect sfText_getRect(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern Vector2f sfText_findCharacterPos(IntPtr CPointer, uint Index);
+        private static extern Vector2f sfText_findCharacterPos(IntPtr CPointer, SIZE_T Index);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern FloatRect sfText_getLocalBounds(IntPtr CPointer);

--- a/src/SFML.Graphics/Texture.cs
+++ b/src/SFML.Graphics/Texture.cs
@@ -5,6 +5,8 @@ using System.Security;
 using SFML.System;
 using SFML.Window;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
@@ -137,7 +139,7 @@ namespace SFML.Graphics
             try
             {
                 IntRect rect = new IntRect(0, 0, 0, 0);
-                CPointer = sfTexture_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length), ref rect);
+                CPointer = sfTexture_createFromMemory(pin.AddrOfPinnedObject(), (SIZE_T)bytes.Length, ref rect);
             }
             finally
             {
@@ -493,7 +495,7 @@ namespace SFML.Graphics
         private static extern IntPtr sfTexture_createFromImage(IntPtr image, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfTexture_createFromMemory(IntPtr data, ulong size, ref IntRect area);
+        private static extern IntPtr sfTexture_createFromMemory(IntPtr data, SIZE_T size, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfTexture_copy(IntPtr texture);

--- a/src/SFML.Graphics/VertexArray.cs
+++ b/src/SFML.Graphics/VertexArray.cs
@@ -3,6 +3,8 @@ using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
@@ -66,7 +68,7 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public uint VertexCount
         {
-            get { return sfVertexArray_getVertexCount(CPointer); }
+            get { return (uint)sfVertexArray_getVertexCount(CPointer); }
         }
 
         ////////////////////////////////////////////////////////////
@@ -203,7 +205,7 @@ namespace SFML.Graphics
         private static extern void sfVertexArray_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern uint sfVertexArray_getVertexCount(IntPtr CPointer);
+        private static extern SIZE_T sfVertexArray_getVertexCount(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern unsafe Vertex* sfVertexArray_getVertex(IntPtr CPointer, uint index);

--- a/src/SFML.Window/VideoMode.cs
+++ b/src/SFML.Window/VideoMode.cs
@@ -2,6 +2,8 @@ using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
 
+using SIZE_T = System.UIntPtr;
+
 namespace SFML.Window
 {
     ////////////////////////////////////////////////////////////
@@ -63,10 +65,10 @@ namespace SFML.Window
             {
                 unsafe
                 {
-                    uint Count;
+                    SIZE_T Count;
                     VideoMode* ModesPtr = sfVideoMode_getFullscreenModes(out Count);
-                    VideoMode[] Modes = new VideoMode[Count];
-                    for (uint i = 0; i < Count; ++i)
+                    VideoMode[] Modes = new VideoMode[(int)Count];
+                    for (int i = 0; i < (int)Count; ++i)
                     {
                         Modes[i] = ModesPtr[i];
                     }
@@ -114,7 +116,7 @@ namespace SFML.Window
         private static extern VideoMode sfVideoMode_getDesktopMode();
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern VideoMode* sfVideoMode_getFullscreenModes(out uint Count);
+        private unsafe static extern VideoMode* sfVideoMode_getFullscreenModes(out SIZE_T Count);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfVideoMode_isValid(VideoMode Mode);


### PR DESCRIPTION
Addresses #212
* Updated to use a `SIZE_T` "typedef" where CSFML is expecting `size_t`
* `using SIZE_T = UIntPtr;` is at the beginning of each file that will P/Invoke functions with `size_t` signatures
* `SIZE_T` is currently typedef'd to `UIntPtr` but this can be changed when `nuint` becomes available to SFML.NET (.NET 5+)
* Since all changes are within protected/private code, this should not represent a breaking change for end-users

* Implemented Font(byte[]) properly using sfFont_createFromMemory() instead of creating a new MemoryStream