### PR TITLE
In-code Documentation Update

### DIFF
--- a/src/SFML.Graphics/PrimitiveType.cs
+++ b/src/SFML.Graphics/PrimitiveType.cs
@@ -4,46 +4,48 @@ namespace SFML.Graphics
 {
     ////////////////////////////////////////////////////////////
     /// <summary>
-    /// Types of primitives that a VertexArray can render.
+    /// Types of primitives that a <see cref="VertexArray"/> or <see cref="VertexBuffer"/> can render.
+    /// </summary>
     ///
+    /// <remarks>
     /// Points and lines have no area, therefore their thickness
     /// will always be 1 pixel, regardless the current transform
     /// and view.
-    /// </summary>
+    /// </remarks>
     ////////////////////////////////////////////////////////////
     public enum PrimitiveType
     {
-        /// List of individual points
+        /// <summary>Individual Points</summary>
         Points,
 
-        /// List of individual lines
+        /// <summary>Individual, Disconnected Lines; each pair of points forms a line</summary>
         Lines,
 
-        /// List of connected lines, a point uses the previous point to form a line
+        /// <summary>Connected Lines; each point starts at the previous point to form a line</summary>
         LineStrip,
 
-        /// List of individual triangles
+        /// <summary>Individual, Disconnected Triangles</summary>
         Triangles,
 
-        /// List of connected triangles, a point uses the two previous points to form a triangle
+        /// <summary>Connected Triangles; each point uses the two previous points to form a triangle</summary>
         TriangleStrip,
 
-        /// List of connected triangles, a point uses the common center and the previous point to form a triangle
+        /// <summary>Connected Triangles; each point uses the first point and the previous point to form a triangle</summary>
         TriangleFan,
 
-        /// List of individual quads
+        /// <summary>Quadrilaterals; each set of four points forms a 4-sided shape</summary>
         Quads,
 
-        /// List of connected lines, a point uses the previous point to form a line
-        [Obsolete("LinesStrip is deprecated, please use LineStrip")]
+        /// <summary><c>DEPRECATED:</c> Use <see cref="LineStrip">LineStrip</see></summary>
+        [Obsolete("LineStrip")]
         LinesStrip = LineStrip,
 
-        /// List of connected triangles, a point uses the two previous points to form a triangle
-        [Obsolete("TrianglesStrip is deprecated, please use TriangleStrip")]
+        /// <summary><c>DEPRECATED:</c> Use <see cref="TriangleStrip">TriangleStrip</see></summary>
+        [Obsolete("Use TriangleStrip")]
         TrianglesStrip = TriangleStrip,
 
-        /// List of connected triangles, a point uses the common center and the previous point to form a triangle
-        [Obsolete("TrianglesFan is deprecated, please use TriangleFan")]
+        /// <summary><c>DEPRECATED:</c> Use <see cref="TriangleFan">TriangleFan</see></summary>
+        [Obsolete("Use TriangleFan")]
         TrianglesFan = TriangleFan,
     }
 }

--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -34,7 +34,7 @@ namespace SFML.Graphics
         /// <param name="height">Height of the render-texture</param>
         /// <param name="depthBuffer">Do you want a depth-buffer attached?</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("Creating a RenderTexture with depthBuffer is deprecated. Use RenderTexture(width, height, contextSettings) instead.")]
+        [Obsolete("Use RenderTexture(width, height, contextSettings)")]
         public RenderTexture(uint width, uint height, bool depthBuffer) :
             base(sfRenderTexture_create(width, height, depthBuffer))
         {
@@ -525,8 +525,7 @@ namespace SFML.Graphics
         private Texture myTexture = null;
 
         #region Imports
-        [Obsolete("sfRenderTexture_create is obselete. Use sfRenderTexture_createWithSettings instead.")]
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
         private static extern IntPtr sfRenderTexture_create(uint Width, uint Height, bool DepthBuffer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -678,7 +678,7 @@ namespace SFML.Graphics
         ///    </code>
         /// </remarks>
         ////////////////////////////////////////////////////////////
-        [Obsolete("Capture is deprecated, please see remarks for preferred method")]
+        [Obsolete("Use Texture and Texture.Update(RenderWindow)")]
         public Image Capture()
         {
             return new Image(sfRenderWindow_capture(CPointer));

--- a/src/SFML.Graphics/Shader.cs
+++ b/src/SFML.Graphics/Shader.cs
@@ -498,7 +498,7 @@ namespace SFML.Graphics
         /// <param name="x">Value to assign</param>
         ///
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, float x)
         {
             sfShader_setFloatParameter(CPointer, name, x);
@@ -516,7 +516,7 @@ namespace SFML.Graphics
         /// <param name="x">First component of the value to assign</param>
         /// <param name="y">Second component of the value to assign</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, float x, float y)
         {
             sfShader_setFloat2Parameter(CPointer, name, x, y);
@@ -535,7 +535,7 @@ namespace SFML.Graphics
         /// <param name="y">Second component of the value to assign</param>
         /// <param name="z">Third component of the value to assign</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, float x, float y, float z)
         {
             sfShader_setFloat3Parameter(CPointer, name, x, y, z);
@@ -555,7 +555,7 @@ namespace SFML.Graphics
         /// <param name="z">Third component of the value to assign</param>
         /// <param name="w">Fourth component of the value to assign</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, float x, float y, float z, float w)
         {
             sfShader_setFloat4Parameter(CPointer, name, x, y, z, w);
@@ -572,7 +572,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the parameter in the shader</param>
         /// <param name="vector">Vector to assign</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, Vector2f vector)
         {
             SetParameter(name, vector.X, vector.Y);
@@ -589,7 +589,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the parameter in the shader</param>
         /// <param name="color">Color to assign</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, Color color)
         {
             sfShader_setColorParameter(CPointer, name, color);
@@ -606,7 +606,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the parameter in the shader</param>
         /// <param name="transform">Transform to assign</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, Transform transform)
         {
             sfShader_setTransformParameter(CPointer, name, transform);
@@ -630,7 +630,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the texture in the shader</param>
         /// <param name="texture">Texture to assign</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, Texture texture)
         {
             // Keep a reference to the Texture so it doesn't get GC'd
@@ -652,7 +652,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the texture in the shader</param>
         /// <param name="current">Always pass the spacial value Shader.CurrentTexture</param>
         ////////////////////////////////////////////////////////////
-        [Obsolete("SetParameter is deprecated, please use the corresponding SetUniform")]
+        [Obsolete("Use SetUniform()")]
         public void SetParameter(string name, CurrentTextureType current)
         {
             sfShader_setCurrentTextureParameter(CPointer, name);

--- a/src/SFML.Graphics/Text.cs
+++ b/src/SFML.Graphics/Text.cs
@@ -18,25 +18,25 @@ namespace SFML.Graphics
     {
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Enumerate the string drawing styles
+        /// Flags for styles that can be applied to the <see cref="Text"/>
         /// </summary>
         ////////////////////////////////////////////////////////////
         [Flags]
         public enum Styles
         {
-            /// <summary>Regular characters, no style</summary>
+            /// <summary>No Style</summary>
             Regular = 0,
 
-            /// <summary>Bold characters</summary>
+            /// <summary>Bold</summary>
             Bold = 1 << 0,
 
-            /// <summary>Italic characters</summary>
+            /// <summary>Italic</summary>
             Italic = 1 << 1,
 
-            /// <summary>Underlined characters</summary>
+            /// <summary>Underlined</summary>
             Underlined = 1 << 2,
 
-            /// <summary>Strike through characters</summary>
+            /// <summary>Strikethrough</summary>
             StrikeThrough = 1 << 3
         }
 
@@ -52,7 +52,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct the text from a string and a font
+        /// Construct the text from a string and a <see cref="SFML.Graphics.Font"/>
         /// </summary>
         /// <param name="str">String to display</param>
         /// <param name="font">Font to use</param>
@@ -64,11 +64,11 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct the text from a string, font and size
+        /// Construct the text from a string, <see cref="SFML.Graphics.Font"/> and size
         /// </summary>
         /// <param name="str">String to display</param>
         /// <param name="font">Font to use</param>
-        /// <param name="characterSize">Base characters size</param>
+        /// <param name="characterSize">Font size</param>
         ////////////////////////////////////////////////////////////
         public Text(string str, Font font, uint characterSize) :
             base(sfText_create())
@@ -80,7 +80,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct the text from another text
+        /// Construct the text from another <see cref="SFML.Graphics.Text"/>
         /// </summary>
         /// <param name="copy">Text to copy</param>
         ////////////////////////////////////////////////////////////
@@ -97,18 +97,20 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Fill color of the object
+        /// DEPRECATED Fill <see cref="SFML.Graphics.Color"/> of the <see cref="Text"/>
         /// </summary>
         /// 
         /// <remarks>
-        /// Deprecated. Use <see cref="FillColor"/> instead.
+        /// Use <see cref="FillColor"/> instead.
         /// 
-        /// By default, the text's fill color is opaque white.
-        /// Setting the fill color to a transparent color with an outline
+        /// By default, the text's fill <see cref="SFML.Graphics.Color"/> is <see cref="SFML.Graphics.Color.White">opaque White</see>.
+        /// <para>
+        /// Setting the fill color to a transparent <see cref="SFML.Graphics.Color"/> with an outline
         /// will cause the outline to be displayed in the fill area of the text.
+        /// </para>
         /// </remarks>
         ////////////////////////////////////////////////////////////
-        [Obsolete]
+        [Obsolete("Use FillColor and OutlineColor")]
         public Color Color
         {
             get { return sfText_getFillColor(CPointer); }
@@ -117,13 +119,15 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Fill color of the object
+        /// Fill <see cref="SFML.Graphics.Color"/> of the <see cref="Text"/>
         /// </summary>
         /// 
         /// <remarks>
-        /// By default, the text's fill color is opaque white.
-        /// Setting the fill color to a transparent color with an outline
+        /// By default, the text's fill <see cref="SFML.Graphics.Color"/> is <see cref="SFML.Graphics.Color.White">opaque White</see>.
+        /// <para>
+        /// Setting the fill color to a transparent <see cref="SFML.Graphics.Color"/> with an outline
         /// will cause the outline to be displayed in the fill area of the text.
+        /// </para>
         /// </remarks>
         ////////////////////////////////////////////////////////////
         public Color FillColor
@@ -134,11 +138,11 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Outline color of the object
+        /// Outline <see cref="SFML.Graphics.Color"/> of the <see cref="Text"/>
         /// </summary>
         /// 
         /// <remarks>
-        /// By default, the text's outline color is opaque black.
+        /// By default, the text's outline <see cref="SFML.Graphics.Color"/> is <see cref="SFML.Graphics.Color.Black">opaque Black</see>.
         /// </remarks>
         ////////////////////////////////////////////////////////////
         public Color OutlineColor
@@ -212,7 +216,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Font used to display the text
+        /// <see cref="SFML.Graphics.Font"/> used to display the text
         /// </summary>
         ////////////////////////////////////////////////////////////
         public Font Font
@@ -256,7 +260,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Style of the text (see Styles enum)
+        /// <see cref="Styles">Style</see> of the text
         /// </summary>
         ////////////////////////////////////////////////////////////
         public Styles Style
@@ -269,8 +273,10 @@ namespace SFML.Graphics
         /// <summary>
         /// Return the visual position of the Index-th character of the text,
         /// in coordinates relative to the text
-        /// (note : translation, origin, rotation and scale are not applied)
         /// </summary>
+        /// <remarks>
+        /// Translation, origin, rotation and scale are not applied.
+        /// </remarks>
         /// <param name="index">Index of the character</param>
         /// <returns>Position of the Index-th character (end of text if Index is out of range)</returns>
         ////////////////////////////////////////////////////////////
@@ -281,14 +287,14 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Get the local bounding rectangle of the entity.
-        ///
-        /// The returned rectangle is in local coordinates, which means
-        /// that it ignores the transformations (translation, rotation,
-        /// scale, ...) that are applied to the entity.
-        /// In other words, this function returns the bounds of the
-        /// entity in the entity's coordinate system.
+        /// Get the local bounding <see cref="FloatRect"/> of the text.
         /// </summary>
+        /// <remarks>
+        /// The returned <see cref="FloatRect"/> is in local coordinates.
+        /// <para>Transformations (Translation, Rotation, Scale) are not applied to the entity.</para>
+        /// <para>In other words, this function returns the bounds of the
+        /// entity in the entity's coordinate system.</para>
+        /// </remarks>
         /// <returns>Local bounding rectangle of the entity</returns>
         ////////////////////////////////////////////////////////////
         public FloatRect GetLocalBounds()
@@ -298,14 +304,14 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Get the global bounding rectangle of the entity.
-        ///
-        /// The returned rectangle is in global coordinates, which means
-        /// that it takes in account the transformations (translation,
-        /// rotation, scale, ...) that are applied to the entity.
-        /// In other words, this function returns the bounds of the
-        /// sprite in the global 2D world's coordinate system.
+        /// Get the global bounding rectangle of the text.
         /// </summary>
+        /// <remarks>
+        /// The returned <see cref="FloatRect"/> is in global coordinates.
+        /// <para>Transformations (Translation, Rotation, Scale) are applied to the entity.</para>
+        /// <para>In other words, this function returns the bounds of the
+        /// sprite in the global 2D world's coordinate system.</para>
+        /// </remarks>
         /// <returns>Global bounding rectangle of the entity</returns>
         ////////////////////////////////////////////////////////////
         public FloatRect GetGlobalBounds()
@@ -335,7 +341,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Draw the text to a render target
+        /// Draw the text to a <see cref="RenderTarget"/>
         /// </summary>
         /// <param name="target">Render target to draw to</param>
         /// <param name="states">Current render states</param>

--- a/src/SFML.Graphics/Texture.cs
+++ b/src/SFML.Graphics/Texture.cs
@@ -18,6 +18,9 @@ namespace SFML.Graphics
         /// <summary>
         /// Construct the texture
         /// </summary>
+        /// <remarks>
+        /// Textures created this way are uninitialized and have indeterminate contents.
+        /// </remarks>
         /// <param name="width">Texture width</param>
         /// <param name="height">Texture height</param>
         /// <exception cref="LoadingFailedException" />

--- a/src/SFML.Graphics/VertexArray.cs
+++ b/src/SFML.Graphics/VertexArray.cs
@@ -24,7 +24,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct the vertex array with a type
+        /// Construct the vertex array with a <see cref="SFML.Graphics.PrimitiveType"/>
         /// </summary>
         /// <param name="type">Type of primitives</param>
         ////////////////////////////////////////////////////////////
@@ -36,7 +36,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct the vertex array with a type and an initial number of vertices
+        /// Construct the vertex array with a <see cref="SFML.Graphics.PrimitiveType"/> and an initial number of vertices
         /// </summary>
         /// <param name="type">Type of primitives</param>
         /// <param name="vertexCount">Initial number of vertices in the array</param>
@@ -50,7 +50,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct the vertex array from another vertex array
+        /// Construct the vertex array from another <see cref="VertexArray"/>
         /// </summary>
         /// <param name="copy">Transformable to copy</param>
         ////////////////////////////////////////////////////////////
@@ -61,7 +61,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Total vertex count
+        /// Total <see cref="Vertex"/> count
         /// </summary>
         ////////////////////////////////////////////////////////////
         public uint VertexCount
@@ -71,14 +71,15 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Read-write access to vertices by their index.
-        ///
+        /// Read-Write access to vertices by their index.
+        /// </summary>
+        /// <remarks>
         /// This function doesn't check index, it must be in range
         /// [0, VertexCount - 1]. The behaviour is undefined
-        /// otherwise.
-        /// </summary>
+        /// otherwise. See <see cref="VertexCount"/>.
+        /// </remarks>
         /// <param name="index">Index of the vertex to get</param>
-        /// <returns>Reference to the index-th vertex</returns>
+        /// <returns>Copy of the index-th vertex.</returns>
         ////////////////////////////////////////////////////////////
         public Vertex this[uint index]
         {
@@ -111,13 +112,14 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Resize the vertex array
-        /// 
-        /// If \a vertexCount is greater than the current size, the previous
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="vertexCount"/> is greater than the current size, the previous
         /// vertices are kept and new (default-constructed) vertices are
         /// added.
-        /// If \a vertexCount is less than the current size, existing vertices
+        /// If <paramref name="vertexCount"/> is less than the current size, existing vertices
         /// are removed from the array.
-        /// </summary>
+        /// </remarks>
         /// <param name="vertexCount">New size of the array (number of vertices)</param>
         ////////////////////////////////////////////////////////////
         public void Resize(uint vertexCount)
@@ -127,7 +129,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Add a vertex to the array
+        /// Add a <see cref="Vertex" /> to the array
         /// </summary>
         /// <param name="vertex">Vertex to add</param>
         ////////////////////////////////////////////////////////////
@@ -140,6 +142,9 @@ namespace SFML.Graphics
         /// <summary>
         /// Type of primitives to draw
         /// </summary>
+        /// <remarks>
+        /// See <see cref="SFML.Graphics.PrimitiveType" />
+        /// </remarks>
         ////////////////////////////////////////////////////////////
         public PrimitiveType PrimitiveType
         {
@@ -150,10 +155,10 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Compute the bounding rectangle of the vertex array.
-        ///
-        /// This function returns the axis-aligned rectangle that
-        /// contains all the vertices of the array.
         /// </summary>
+        /// <remarks>
+        /// Contains the axis-aligned <see cref="FloatRect"/> that contains all the vertices of the array.
+        /// </remarks>
         ////////////////////////////////////////////////////////////
         public FloatRect Bounds
         {
@@ -162,7 +167,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Draw the vertex array to a render target
+        /// Draw the vertex array to a <see cref="RenderTarget" />
         /// </summary>
         /// <param name="target">Render target to draw to</param>
         /// <param name="states">Current render states</param>

--- a/src/SFML.Graphics/VertexBuffer.cs
+++ b/src/SFML.Graphics/VertexBuffer.cs
@@ -18,46 +18,49 @@ namespace SFML.Graphics
     {
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Usage specifiers
-        ///
-        /// If data is going to be updated once or more every frame,
-        /// set the usage to Stream. If data is going
-        /// to be set once and used for a long time without being
-        /// modified, set the usage to Static.
-        /// For everything else Dynamic should
-        /// be a good compromise.
+        /// <see cref="VertexBuffer"/> Usage Specifiers
         /// </summary>
+        /// <remarks>
+        /// <para>If data is going to be updated once or more every frame, use <see cref="Stream"/>.</para>
+        /// <para>If data is going to be set once and used for a long time without being modified, use <see cref="Static"/>.</para>
+        /// <para>For everything else, <see cref="Dynamic"/> should be a good compromise.</para>
+        /// </remarks>
         ////////////////////////////////////////////////////////////
         public enum UsageSpecifier
         {
             /// <summary>Constantly changing data.</summary>
+            /// <remarks>Use when the <see cref="VertexBuffer"/> will be updated once or more every frame.</remarks>
             Stream,
             /// <summary>Occasionally changing data.</summary>
+            /// <remarks>Use when the <see cref="VertexBuffer"/> will change infrequently.</remarks>
             Dynamic,
             /// <summary>Rarely changing data.</summary>
+            /// <remarks>Use when the <see cref="VertexBuffer"/> will rarely of never be changed.</remarks>
             Static
         }
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Whether or not the system supports vertex buffers
-        ///
+        /// Whether or not the system supports <see cref="VertexBuffer"/>s
+        /// </summary>
+        /// <remarks>
         /// This function should always be called before using
         /// the vertex buffer features. If it returns false, then
-        /// any attempt to use sf::VertexBuffer will fail.
-        /// </summary>
+        /// any attempt to use <see cref="VertexBuffer"/> will fail.
+        /// </remarks>
         ///////////////////////////////////////////////////////////
         public static bool Available { get { return sfVertexBuffer_isAvailable(); } }
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Create a new vertex buffer with a specific
-        /// PrimitiveType and usage specifier.
-        ///
-        /// Creates the vertex buffer, allocating enough graphcis
-        /// memory to hold \p vertexCount vertices, and sets its
-        /// primitive type to \p type and usage to \p usage.
+        /// Create a new <see cref="VertexBuffer"/> with a specific
+        /// <see cref="SFML.Graphics.PrimitiveType"/> and <see cref="UsageSpecifier"/>
         /// </summary>
+        /// <remarks>
+        /// Creates the vertex buffer, allocating enough graphics
+        /// memory to hold <paramref name="vertexCount"/> vertices, and sets its
+        /// <see cref="SFML.Graphics.PrimitiveType"/> to primitiveType and <see cref="UsageSpecifier"/> to usageType.
+        /// </remarks>
         /// <param name="vertexCount">Amount of vertices</param>
         /// <param name="primitiveType">Type of primitives</param>
         /// <param name="usageType">Usage specifier</param>
@@ -69,7 +72,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct the vertex buffer from another vertex array
+        /// Construct the vertex buffer from another <see cref="VertexBuffer"/>
         /// </summary>
         /// <param name="copy">VertexBuffer to copy</param>
         ////////////////////////////////////////////////////////////
@@ -88,11 +91,12 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// OpenGL handle of the vertex buffer or 0 if not yet created
-        /// 
+        /// </summary>
+        /// <remarks>
         /// You shouldn't need to use this property, unless you have
         /// very specific stuff to implement that SFML doesn't support,
         /// or implement a temporary workaround until a bug is fixed.
-        /// </summary>
+        /// </remarks>
         ////////////////////////////////////////////////////////////
         public uint NativeHandle
         {
@@ -101,7 +105,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// The type of primitives drawn by the vertex buffer
+        /// The <see cref="SFML.Graphics.PrimitiveType"/> drawn by the <see cref="VertexBuffer"/>
         /// </summary>
         ////////////////////////////////////////////////////////////
         public PrimitiveType PrimitiveType
@@ -112,7 +116,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// The usage specifier for the vertex buffer
+        /// The <see cref="UsageSpecifier"/> for the <see cref="VertexBuffer"/>
         /// </summary>
         ////////////////////////////////////////////////////////////
         public UsageSpecifier Usage
@@ -123,44 +127,54 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Bind a vertex buffer for rendering.
-        /// 
-        /// This function is not part of the graphics API, it mustn't
-        /// be used when drawing SFML entities. It must be used only if
-        /// you mix VertexBuffer with OpenGL code.
+        /// Bind a <see cref="VertexBuffer"/> for rendering.
         /// </summary>
-        /// <param name="vertexBuffer">The vertex buffer to bind, can be null to use no vertex buffer</param>
+        /// <remarks>
+        /// <para>This function is not part of the graphics API.</para>
+        /// <para>It must not be used when drawing SFML entities.</para>
+        /// <para>It must be used only if you mix VertexBuffer with OpenGL code.</para>
+        /// </remarks>
+        /// <param name="vertexBuffer">The vertex buffer to bind; can be null to use no vertex buffer</param>
         ////////////////////////////////////////////////////////////
         public static void Bind(VertexBuffer vertexBuffer)
         {
             sfVertexBuffer_bind(vertexBuffer?.CPointer ?? IntPtr.Zero);
         }
-		
+
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Update a part of the buffer from an array of vertices
-        /// offset is specified as the number of vertices to skip
+        /// Update the <see cref="VertexBuffer"/> from a <see cref="Vertex"/>[]
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <pararef name="offset" /> is specified as the number of vertices to skip
         /// from the beginning of the buffer.
-        ///
-        /// If offset is 0 and vertexCount is equal to the size of
+        /// </para>
+        /// <para>
+        /// If <pararef name="offset" /> is 0 and <paramref name="vertexCount" /> is equal to the size of
         /// the currently created buffer, its whole contents are replaced.
-        ///
-        /// If offset is 0 and vertexCount is greater than the
+        /// </para>
+        /// <para>
+        /// If <pararef name="offset" /> is 0 and <paramref name="vertexCount" /> is greater than the
         /// size of the currently created buffer, a new buffer is created
-        /// containing the vertex data.
-        ///
-        /// If offset is 0 and vertexCount is less than the size of
+        /// containing the <see cref="Vertex"/> data.
+        /// </para>
+        /// <para>
+        /// If <pararef name="offset" /> is 0 and <paramref name="vertexCount" /> is less than the size of
         /// the currently created buffer, only the corresponding region
         /// is updated.
-        ///
-        /// If offset is not 0 and offset + vertexCount is greater
-        /// than the size of the currently created buffer, the update fails.
-        ///
-        /// No additional check is performed on the size of the vertex
-        /// array, passing invalid arguments will lead to undefined
-        /// behavior.
-        /// </summary>
-        /// <param name="vertices">Array of vertices to copy to the buffer</param>
+        /// </para>
+        /// <para>
+        /// If <pararef name="offset" /> is NOT 0 and <pararef name="offset" /> +
+        /// <paramref name="vertexCount" /> is greater than the size of the currently
+        /// created buffer, the update fails.
+        /// </para>
+        /// <para>
+        /// No additional checks are performed on the size of the <see cref="VertexBuffer"/>.
+        /// Passing invalid arguments will lead to undefined behavior.
+        /// </para>
+        /// </remarks>
+        /// <param name="vertices">Array of vertices to copy from</param>
         /// <param name="vertexCount">Number of vertices to copy</param>
         /// <param name="offset">Offset in the buffer to copy to</param>
         ////////////////////////////////////////////////////////////
@@ -177,27 +191,28 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Update a part of the buffer from an array of vertices
-        /// assuming an offset of 0 and a vertex count the length of the passed array.
-        ///
-        /// If offset is 0 and vertexCount is equal to the size of
-        /// the currently created buffer, its whole contents are replaced.
-        ///
-        /// If offset is 0 and vertexCount is greater than the
-        /// size of the currently created buffer, a new buffer is created
-        /// containing the vertex data.
-        ///
-        /// If offset is 0 and vertexCount is less than the size of
-        /// the currently created buffer, only the corresponding region
-        /// is updated.
-        ///
-        /// If offset is not 0 and offset + vertexCount is greater
-        /// than the size of the currently created buffer, the update fails.
-        ///
-        /// No additional check is performed on the size of the vertex
-        /// array, passing invalid arguments will lead to undefined
-        /// behavior.
+        /// Update a part of the buffer from a <see cref="Vertex"/>[]
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the length of <paramref name="vertices" /> is equal
+        /// to the current size of the buffer, the entire buffer is replaced.
+        /// </para>
+        /// <para>
+        /// If the length of <paramref name="vertices" /> is greater than the
+        /// current size of the buffer, a new buffer is created containing
+        /// the <see cref="Vertex"/> data.
+        /// </para>
+        /// <para>
+        /// If the length of <paramref name="vertices" /> is less than the
+        /// current size of the buffer, only the first <paramref name="vertices" />.Length
+        /// vertices are replaced.
+        /// </para>
+        /// <para>
+        /// No additional checks are performed on <paramref name="vertices" />.Length.
+        /// Passing invalid arguments will lead to undefined behavior.
+        /// </para>
+        /// </remarks>
         /// <param name="vertices">Array of vertices to copy to the buffer</param>
         ////////////////////////////////////////////////////////////
         public bool Update(Vertex[] vertices)
@@ -207,27 +222,37 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Update a part of the buffer from an array of vertices
-        /// assuming a vertex count the length of the passed array.
-        ///
-        /// If offset is 0 and vertexCount is equal to the size of
-        /// the currently created buffer, its whole contents are replaced.
-        ///
-        /// If offset is 0 and vertexCount is greater than the
-        /// size of the currently created buffer, a new buffer is created
-        /// containing the vertex data.
-        ///
-        /// If offset is 0 and vertexCount is less than the size of
-        /// the currently created buffer, only the corresponding region
-        /// is updated.
-        ///
-        /// If offset is not 0 and offset + vertexCount is greater
-        /// than the size of the currently created buffer, the update fails.
-        ///
-        /// No additional check is performed on the size of the vertex
-        /// array, passing invalid arguments will lead to undefined
-        /// behavior.
+        /// Update a part of the buffer from a <see cref="Vertex"/>[]
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <pararef name="offset" /> is specified as the number of vertices to skip
+        /// from the beginning of the buffer.
+        /// </para>
+        /// <para>
+        /// If <pararef name="offset" /> is 0 and <paramref name="vertices" />.Length
+        /// is equal to the size of the currently created buffer, its whole contents are replaced.
+        /// </para>
+        /// <para>
+        /// If <pararef name="offset" /> is 0 and <paramref name="vertices" />.Length
+        /// is greater than the size of the currently created buffer, a new buffer is created
+        /// containing the <see cref="Vertex"/> data.
+        /// </para>
+        /// <para>
+        /// If <pararef name="offset" /> is 0 and <paramref name="vertices" />.Length
+        /// is less than the size of the currently created buffer, only the first
+        /// <paramref name="vertices" />.Length vertices are replaced.
+        /// </para>
+        /// <para>
+        /// If <pararef name="offset" /> is NOT 0 and <pararef name="offset" /> +
+        /// <paramref name="vertices" />.Length is greater than the size of the currently
+        /// created buffer, the update fails.
+        /// </para>
+        /// <para>
+        /// No additional checks are performed on the size of the <see cref="VertexBuffer"/>.
+        /// Passing invalid arguments will lead to undefined behavior.
+        /// </para>
+        /// </remarks>
         /// <param name="vertices">Array of vertices to copy to the buffer</param>
         /// <param name="offset">Offset in the buffer to copy to</param>
         ////////////////////////////////////////////////////////////
@@ -238,9 +263,9 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Copy the contents of another buffer into this buffer
+        /// Copy the contents of another <see cref="VertexBuffer"/> into this buffer
         /// </summary>
-        /// <param name="other">Vertex buffer whose contents to copy into first vertex buffer</param>
+        /// <param name="other">VertexBuffer whose contents to copy from</param>
         ////////////////////////////////////////////////////////////
         public bool Update(VertexBuffer other)
         {
@@ -249,9 +274,9 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Swap the contents of another buffer into this buffer
+        /// Swap the contents of another <see cref="VertexBuffer"/> into this buffer
         /// </summary>
-        /// <param name="other">Vertex buffer whose contents to swap with</param>
+        /// <param name="other">VertexBuffer whose contents to swap with</param>
         ////////////////////////////////////////////////////////////
         public void Swap(VertexBuffer other)
         {
@@ -271,7 +296,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Draw the vertex buffer to a render target
+        /// Draw the <see cref="VertexBuffer"/> to a <see cref="RenderTarget"/>
         /// </summary>
         /// <param name="target">Render target to draw to</param>
         /// <param name="states">Current render states</param>

--- a/src/SFML.System/Time.cs
+++ b/src/SFML.System/Time.cs
@@ -6,8 +6,14 @@ namespace SFML.System
 {
     ////////////////////////////////////////////////////////////
     /// <summary>
-    /// This class represents a time value
+    /// A Time value for interfacing with SFML
     /// </summary>
+    /// <remarks>
+    /// <para>Using <see cref="TimeSpan"/> while working within managed code is best.</para>
+    /// <para>In most cases, <see cref="Time"/> is only needed when calling into unmanaged code.</para>
+    /// <para>Implicit casts from <see cref="TimeSpan"/> to <see cref="Time"/>
+    /// allow <see cref="TimeSpan"/>s to be used for most SFML methods.</para>
+    /// </remarks>
     ////////////////////////////////////////////////////////////
     [StructLayout(LayoutKind.Sequential)]
     public struct Time : IEquatable<Time>
@@ -21,71 +27,71 @@ namespace SFML.System
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct a time value from a number of seconds
+        /// Construct a <see cref="Time"/> from a number of seconds
         /// </summary>
         /// <param name="seconds">Number of seconds</param>
-        /// <returns>Time value constructed from the amount of seconds</returns>
+        /// <returns>Time constructed from the amount of seconds</returns>
         ////////////////////////////////////////////////////////////
         public static Time FromSeconds(float seconds) => sfSeconds(seconds);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct a time value from a number of milliseconds
+        /// Construct a <see cref="Time"/> from a number of milliseconds
         /// </summary>
         /// <param name="milliseconds">Number of milliseconds</param>
-        /// <returns>Time value constructed from the amount of milliseconds</returns>
+        /// <returns>Time constructed from the amount of milliseconds</returns>
         ////////////////////////////////////////////////////////////
         public static Time FromMilliseconds(int milliseconds) => sfMilliseconds(milliseconds);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct a time value from a number of microseconds
+        /// Construct a <see cref="Time"/> from a number of microseconds
         /// </summary>
         /// <param name="microseconds">Number of microseconds</param>
-        /// <returns>Time value constructed from the amount of microseconds</returns>
+        /// <returns>Time constructed from the amount of microseconds</returns>
         ////////////////////////////////////////////////////////////
         public static Time FromMicroseconds(long microseconds) => sfMicroseconds(microseconds);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Construct a Time value from a TimeSpan
+        /// Construct a <see cref="Time"/> from a <see cref="TimeSpan"/>
         /// </summary>
         /// <param name="timeSpan">A TimeSpan representing the amount of time to represent</param>
-        /// <returns>Time value constructed from an existing TimeSpan</returns>
+        /// <returns>Time constructed from an existing TimeSpan</returns>
         ////////////////////////////////////////////////////////////
         public static Time FromTimeSpan(TimeSpan timeSpan) => sfMicroseconds(timeSpan.Ticks * 1000 / TimeSpan.TicksPerMillisecond);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Returns the time value as a number of seconds
+        /// Returns the <see cref="Time"/> as a number of seconds
         /// </summary>
         ////////////////////////////////////////////////////////////
         public float AsSeconds() => microseconds / 1000000f;
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Returns the time value as a number of milliseconds
+        /// Returns the <see cref="Time"/> as a number of milliseconds
         /// </summary>
         ////////////////////////////////////////////////////////////
         public int AsMilliseconds() => (int)(microseconds / 1000);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Returns the time value as a number of microseconds
+        /// Returns the <see cref="Time"/> as a number of microseconds
         /// </summary>
         ////////////////////////////////////////////////////////////
         public long AsMicroseconds() => microseconds;
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Returns the time value as a TimeSpan
+        /// Returns the <see cref="Time"/> as a TimeSpan
         /// </summary>
         ////////////////////////////////////////////////////////////
         public TimeSpan ToTimeSpan() => TimeSpan.FromTicks(microseconds * (TimeSpan.TicksPerMillisecond / 1000));
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Implicit conversion from TimeSpan to SFML.System.Time, allowing intuitive use
+        /// Implicit conversion from <see cref="TimeSpan"/> to <see cref="Time"/>, allowing intuitive use
         /// </summary>
         ////////////////////////////////////////////////////////////
         public static implicit operator Time(TimeSpan timeSpan) => FromTimeSpan(timeSpan);

--- a/src/SFML.Window/Event.cs
+++ b/src/SFML.Window/Event.cs
@@ -31,8 +31,8 @@ namespace SFML.Window
         /// <summary>Event triggered when a keyboard key is released</summary>
         KeyReleased,
 
-        /// <summary>Event triggered when the mouse wheel is scrolled (deprecated)</summary>
-        [Obsolete("MouseWheelMoved is deprecated, please use MouseWheelScrolled instead")]
+        /// <summary>Event triggered when the mouse wheel is scrolled</summary>
+        [Obsolete("Use MouseWheelScrolled")]
         MouseWheelMoved,
 
         /// <summary>Event triggered when a mouse wheel is scrolled</summary>
@@ -89,7 +89,7 @@ namespace SFML.Window
     [StructLayout(LayoutKind.Sequential)]
     public struct KeyEvent
     {
-        /// <summary>Code of the key (see KeyCode enum)</summary>
+        /// <summary>Code of the key. See <see cref="Keyboard.Key"/></summary>
         public Keyboard.Key Code;
 
         /// <summary>Is the Alt modifier pressed?</summary>
@@ -156,7 +156,7 @@ namespace SFML.Window
     /// </summary>
     ////////////////////////////////////////////////////////////
     [StructLayout(LayoutKind.Sequential)]
-    [Obsolete("MouseWheelEvent is deprecated, please use MouseWheelScrollEvent instead")]
+    [Obsolete("Use MouseWheelScrollEvent")]
     public struct MouseWheelEvent
     {
         /// <summary>Scroll amount</summary>
@@ -323,7 +323,7 @@ namespace SFML.Window
 
         /// <summary>Arguments for mouse wheel events (MouseWheelMoved)</summary>
         [FieldOffset(4)]
-        [Obsolete("MouseWheel is deprecated, please use MouseWheelScroll instead")]
+        [Obsolete("Use MouseWheelScroll")]
         public MouseWheelEvent MouseWheel;
 
         /// <summary>Arguments for mouse wheel scroll events (MouseWheelScrolled)</summary>

--- a/src/SFML.Window/EventArgs.cs
+++ b/src/SFML.Window/EventArgs.cs
@@ -178,7 +178,7 @@ namespace SFML.Window
     /// Mouse wheel event parameters
     /// </summary>
     ////////////////////////////////////////////////////////////
-    [Obsolete("MouseWheelEventArgs is deprecated, please use MouseWheelScrollEventArgs instead")]
+    [Obsolete("Use MouseWheelScrollEventArgs")]
     public class MouseWheelEventArgs : EventArgs
     {
         ////////////////////////////////////////////////////////////

--- a/src/SFML.Window/Keyboard.cs
+++ b/src/SFML.Window/Keyboard.cs
@@ -229,19 +229,19 @@ namespace SFML.Window
 
             // Deprecated backwards compatible stuff
             /// <summary>DEPRECATED: Use Hyphen</summary>
-            [Obsolete("Deprecated: Use Hyphen instead.")]
+            [Obsolete("Replace with Hyphen")]
             Dash = Hyphen,
             /// <summary>DEPRECATED: Use Backspace</summary>
-            [Obsolete("Deprecated: Use Backspace instead.")]
+            [Obsolete("Replace with Backspace")]
             BackSpace = Backspace,
             /// <summary>DEPRECATED: Use Enter</summary>
-            [Obsolete("Deprecated: Use Enter instead.")]
+            [Obsolete("Replace with Enter")]
             Return = Enter,
             /// <summary>DEPRECATED: Use Backslash</summary>
-            [Obsolete("Deprecated: Use Backslash instead.")]
+            [Obsolete("Replace with Backslash")]
             BackSlash = Backslash,
             /// <summary>DEPRECATED: Use Semicolon</summary>
-            [Obsolete("Deprecated: Use Semicolon instead.")]
+            [Obsolete("Replace with Semicolon")]
             SemiColon = Semicolon
         };
 

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -731,7 +731,7 @@ namespace SFML.Window
         public event EventHandler<KeyEventArgs> KeyReleased = null;
 
         /// <summary>Event handler for the MouseWheelMoved event</summary>
-        [Obsolete("MouseWheelMoved is deprecated, please use MouseWheelScrolled instead")]
+        [Obsolete("Use MouseWheelScrolled")]
         public event EventHandler<MouseWheelEventArgs> MouseWheelMoved = null;
 
         /// <summary>Event handler for the MouseWheelScrolled event</summary>


### PR DESCRIPTION
This is an absolute doozy of a diff, but it's all within comments and doesn't include any actual code changes.  It also adds clarity to a couple of quirks that are discussed in #194 and #195 

* Addresses requests in #194 and #195
* Updated all [Obsolete] attributes to be less repetitive
* Added a large number of quick reference links to existing summaries
* Corrected various typos and unparsable markup(\a and \p)
* Added additional formatting to numerous summaries, resulting in more readable tooltips
* Added a suggestion to use TimeSpan over SFML's Time while working within a managed environment