### PR TITLE
fix Window constructor's dummy

### DIFF
--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -50,7 +50,7 @@ namespace SFML.Graphics
         /// <param name="settings">Creation parameters</param>
         ////////////////////////////////////////////////////////////
         public RenderWindow(VideoMode mode, string title, Styles style, ContextSettings settings) :
-            base(IntPtr.Zero, 0)
+            base(IntPtr.Zero)
         {
             // Copy the string to a null-terminated UTF-32 byte array
             byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
@@ -84,7 +84,7 @@ namespace SFML.Graphics
         /// <param name="settings">Creation parameters</param>
         ////////////////////////////////////////////////////////////
         public RenderWindow(IntPtr handle, ContextSettings settings) :
-            base(sfRenderWindow_createFromHandle(handle, ref settings), 0)
+            base(sfRenderWindow_createFromHandle(handle, ref settings))
         {
             Initialize();
         }

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -92,23 +92,12 @@ namespace SFML.Window
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Create the window from an existing control with default creation settings
-        /// </summary>
-        /// <param name="handle">Platform-specific handle of the control</param>
-        ////////////////////////////////////////////////////////////
-        public Window(IntPtr handle) :
-            this(handle, new ContextSettings(0, 0))
-        {
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
         /// Create the window from an existing control
         /// </summary>
         /// <param name="Handle">Platform-specific handle of the control</param>
         /// <param name="settings">Creation parameters</param>
         ////////////////////////////////////////////////////////////
-        public Window(IntPtr Handle, ContextSettings settings) :
+        public Window(IntPtr Handle, ContextSettings settings=default) :
             base(sfWindow_createFromHandle(Handle, ref settings))
         {
         }
@@ -423,12 +412,10 @@ namespace SFML.Window
         /// Constructor for derived classes
         /// </summary>
         /// <param name="cPointer">Pointer to the internal object in the C API</param>
-        /// <param name="dummy">Internal hack :)</param>
         ////////////////////////////////////////////////////////////
-        protected Window(IntPtr cPointer, int dummy) :
+        protected Window(IntPtr cPointer) :
             base(cPointer)
         {
-            // TODO : find a cleaner way of separating this constructor from Window(IntPtr handle)
         }
 
         ////////////////////////////////////////////////////////////


### PR DESCRIPTION
# What this PR does

There is a TODO on a protected constructor of the `Window` class

```csharp
// Let's call this constructor A
protected Window(IntPtr cPointer, int dummy) :
    base(cPointer)
{
    // TODO : find a cleaner way of separating this constructor from Window(IntPtr handle)
}
```
This is due to an existing public constructor

```csharp
// Let's call this constructor B
public Window(IntPtr handle) :
    this(handle, new ContextSettings(0, 0))
{
}

// Let's call this constructor C
public Window(IntPtr Handle, ContextSettings settings) :
    base(sfWindow_createFromHandle(Handle, ref settings))
{
}
```

The dummy variable is present in constructor A because removing it would clash with B, which just passes the value of `ContextSettings` object to C.

This PR fixes it by removing B, and change C to make the `ContextSettings` parameter as optional.

```csharp
public Window(IntPtr Handle, ContextSettings settings=default) :
    base(sfWindow_createFromHandle(Handle, ref settings))
{
}
```

The [default operator](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/default) in C# returns a struct with the default constructor called on it (Which would set all values of the `ContextSettings` object to 0) for structs(value types), while it returns `null` for class(reference types)

This can be demonstrated with this code

```csharp
SFML.Window.ContextSettings settings = default;
System.Console.WriteLine(settings);
```

This gives the following output

```
[ContextSettings] DepthBits(0) StencilBits(0) AntialiasingLevel(0) MajorVersion(0) MinorVersion(0) AttributeFlags(Default) SRgbCapable(False)
```

This means `B` is no longer needed, and therefore the dummy variable in `A` can also be removed. 

This works because for any function call, C# first checks if there are any functions that exactly match the function signature, and only then tries to match the function signature with optional arguments

So a call to the window constructor as such would call for `C`

```csharp
var win1 = new SFML.Window.Window(nint.Zero); // A is inaccessible, so calls for C
```

and for the constructor calls within `RenderWindow`, `A` is accessible and exactly matches the function signature, so it calls for `A` as expected.

# File(s) changed
The constructors `A`,`B`,`C` in file `Window.cs` and references to `A` in `RenderWindow.cs`  are modified.

> src/SFML.Window/Window.cs

> src/SFML.Graphics/RenderWindow.cs