### PR TITLE
Implement most CSFML 2.6.0 features

### DIFF
--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -15,7 +15,13 @@ namespace SFML.Audio
     {
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Constructs a music from an audio file
+        /// Constructs a music from a file
+        ///
+        /// This constructor doesn't start playing the music (call
+        /// <see cref="Play"/> to do so).
+        /// Here is a complete list of all the supported audio formats:
+        /// ogg, wav, flac, mp3, aiff, au, raw, paf, svx, nist, voc, ircam,
+        /// w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
         /// </summary>
         /// <param name="filename">Path of the music file to open</param>
         ////////////////////////////////////////////////////////////
@@ -31,6 +37,12 @@ namespace SFML.Audio
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Constructs a music from a custom stream
+        ///
+        /// This constructor doesn't start playing the music (call
+        /// <see cref="Play"/> to do so).
+        /// Here is a complete list of all the supported audio formats:
+        /// ogg, wav, flac, mp3, aiff, au, raw, paf, svx, nist, voc, ircam,
+        /// w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
         /// </summary>
         /// <param name="stream">Source stream to read from</param>
         ////////////////////////////////////////////////////////////
@@ -49,6 +61,12 @@ namespace SFML.Audio
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Constructs a music from an audio file in memory
+        ///
+        /// This constructor doesn't start playing the music (call
+        /// <see cref="Play"/> to do so).
+        /// Here is a complete list of all the supported audio formats:
+        /// ogg, wav, flac, mp3, aiff, au, raw, paf, svx, nist, voc, ircam,
+        /// w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
         /// </summary>
         /// <param name="bytes">Byte array containing the file contents</param>
         /// <exception cref="LoadingFailedException" />

--- a/src/SFML.Audio/SoundBuffer.cs
+++ b/src/SFML.Audio/SoundBuffer.cs
@@ -18,7 +18,7 @@ namespace SFML.Audio
         /// Construct a sound buffer from a file
         /// 
         /// Here is a complete list of all the supported audio formats:
-        /// ogg, wav, flac, aiff, au, raw, paf, svx, nist, voc, ircam,
+        /// ogg, wav, flac, mp3, aiff, au, raw, paf, svx, nist, voc, ircam,
         /// w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
         /// </summary>
         /// <param name="filename">Path of the sound file to load</param>
@@ -38,7 +38,7 @@ namespace SFML.Audio
         /// Construct a sound buffer from a custom stream.
         ///
         /// Here is a complete list of all the supported audio formats:
-        /// ogg, wav, flac, aiff, au, raw, paf, svx, nist, voc, ircam,
+        /// ogg, wav, flac, mp3, aiff, au, raw, paf, svx, nist, voc, ircam,
         /// w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
         /// </summary>
         /// <param name="stream">Source stream to read from</param>
@@ -63,7 +63,7 @@ namespace SFML.Audio
         /// Construct a sound buffer from a file in memory.
         /// 
         /// Here is a complete list of all the supported audio formats:
-        /// ogg, wav, flac, aiff, au, raw, paf, svx, nist, voc, ircam,
+        /// ogg, wav, flac, mp3, aiff, au, raw, paf, svx, nist, voc, ircam,
         /// w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
         /// </summary>
         /// <param name="bytes">Byte array containing the file contents</param>
@@ -129,7 +129,7 @@ namespace SFML.Audio
         /// Save the sound buffer to an audio file.
         ///
         /// Here is a complete list of all the supported audio formats:
-        /// ogg, wav, flac, aiff, au, raw, paf, svx, nist, voc, ircam,
+        /// ogg, wav, flac, mp3, aiff, au, raw, paf, svx, nist, voc, ircam,
         /// w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
         /// </summary>
         /// <param name="filename">Path of the sound file to write</param>

--- a/src/SFML.Graphics/BlendMode.cs
+++ b/src/SFML.Graphics/BlendMode.cs
@@ -63,7 +63,13 @@ namespace SFML.Graphics
             Subtract,
 
             /// <summary>Pixel = Dst * DstFactor - Src * SrcFactor</summary>
-            ReverseSubtract
+            ReverseSubtract,
+
+            /// <summary>Pixel = min(Dst, Src)</summary>
+            Min,
+
+            /// <summary>Pixel = max(Dst, Src)</summary>
+            Max
         }
 
         /// <summary>Blend source and dest according to dest alpha</summary>
@@ -77,9 +83,14 @@ namespace SFML.Graphics
         /// <summary>Multiply source and dest</summary>
         public static readonly BlendMode Multiply = new BlendMode(Factor.DstColor, Factor.Zero);
 
+        /// <summary>Take minimum between source and dest</summary>
+        public static readonly BlendMode Min = new BlendMode(Factor.One, Factor.One, Equation.Min);
+
+        /// <summary>Take maximum between source and dest</summary>
+        public static readonly BlendMode Max = new BlendMode(Factor.One, Factor.One, Equation.Max);
+
         /// <summary>Overwrite dest with source</summary>
         public static readonly BlendMode None = new BlendMode(Factor.One, Factor.Zero);
-
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.Graphics/Font.cs
+++ b/src/SFML.Graphics/Font.cs
@@ -81,14 +81,27 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Get the kerning offset between two glyphs
+        /// Get the kerning value corresponding to a given pair of
+        /// characters in a font
         /// </summary>
         /// <param name="first">Unicode code point of the first character</param>
         /// <param name="second">Unicode code point of the second character</param>
-        /// <param name="characterSize">Character size</param>
+        /// <param name="characterSize">Character size, in pixels</param>
         /// <returns>Kerning offset, in pixels</returns>
         ////////////////////////////////////////////////////////////
         public float GetKerning(uint first, uint second, uint characterSize) => sfFont_getKerning(CPointer, first, second, characterSize);
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Get the bold kerning value corresponding to a given pair
+        /// of characters in a font
+        /// </summary>
+        /// <param name="first">Unicode code point of the first character</param>
+        /// <param name="second">Unicode code point of the second character</param>
+        /// <param name="characterSize">Character size, in pixels</param>
+        /// <returns>Kerning offset, in pixels</returns>
+        ////////////////////////////////////////////////////////////
+        public float GetBoldKerning(uint first, uint second, uint characterSize) => sfFont_getBoldKerning(CPointer, first, second, characterSize);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -129,6 +142,28 @@ namespace SFML.Graphics
             myTextures[characterSize] = new Texture(sfFont_getTexture(CPointer, characterSize));
             return myTextures[characterSize];
         }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Enable or disable the smooth filter
+        ///
+        /// When the filter is activated, the font appears smoother
+        /// so that pixels are less noticeable. However if you want
+        /// the font to look exactly the same as its source file,
+        /// you should disable it.
+        /// The smooth filter is enabled by default.
+        /// </summary>
+        /// <param name="smooth">True to enable smoothing, false to disable it</param>
+        ////////////////////////////////////////////////////////////
+        public void SetSmooth(bool smooth) => sfFont_setSmooth(CPointer, smooth);
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Tell whether the smooth filter is enabled or disabled
+        /// </summary>
+        /// <returns>True if smoothing is enabled, false if it is disabled</returns>
+        ////////////////////////////////////////////////////////////
+        public bool IsSmooth() => sfFont_isSmooth(CPointer);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -245,6 +280,9 @@ namespace SFML.Graphics
         private static extern float sfFont_getKerning(IntPtr CPointer, uint first, uint second, uint characterSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern float sfFont_getBoldKerning(IntPtr CPointer, uint first, uint second, uint characterSize);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern float sfFont_getLineSpacing(IntPtr CPointer, uint characterSize);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
@@ -255,6 +293,12 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfFont_getTexture(IntPtr CPointer, uint characterSize);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfFont_setSmooth(IntPtr CPointer, bool smooth);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfFont_isSmooth(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern InfoMarshalData sfFont_getInfo(IntPtr CPointer);

--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -187,6 +187,30 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Save the image to a buffer in memory
+        /// 
+        /// The format of the image must be specified.
+        /// The supported image formats are bmp, png, tga and jpg.
+        /// This function fails if the image is empty, or if
+        /// the format was invalid.
+        /// </summary>
+        /// <param name="output">Byte array filled with encoded data</param>
+        /// <param name="format">Encoding format to use</param>
+        /// <returns>True if saving was successful</returns>
+        ////////////////////////////////////////////////////////////
+        public bool SaveToMemory(out byte[] output, string format)
+        {
+            using (SFML.System.Buffer buffer = new SFML.System.Buffer())
+            {
+                bool success = sfImage_saveToMemory(CPointer, buffer.CPointer, format);
+
+                output = success ? buffer.GetData() : Array.Empty<byte>();
+                return success;
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Create a transparency mask from a specified colorkey
         /// </summary>
         /// <param name="color">Color to become transparent</param>
@@ -375,6 +399,9 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfImage_saveToFile(IntPtr CPointer, string Filename);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfImage_saveToMemory(IntPtr CPointer, IntPtr bufferOutput, string format);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfImage_createMaskFromColor(IntPtr CPointer, Color Col, byte Alpha);

--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -202,7 +202,7 @@ namespace SFML.Graphics
         {
             using (SFML.System.Buffer buffer = new SFML.System.Buffer())
             {
-                bool success = sfImage_saveToMemory(CPointer, buffer.CPointer, format);
+                var success = sfImage_saveToMemory(CPointer, buffer.CPointer, format);
 
                 output = success ? buffer.GetData() : Array.Empty<byte>();
                 return success;

--- a/src/SFML.Graphics/Rect.cs
+++ b/src/SFML.Graphics/Rect.cs
@@ -124,6 +124,22 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Get the position of the rectangle's top-left corner
+        /// </summary>
+        /// <returns>Position of rectangle</returns>
+        ////////////////////////////////////////////////////////////
+        public Vector2i Position => new Vector2i(Left, Top);
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Get the size of the rectangle
+        /// </summary>
+        /// <returns>Size of rectangle</returns>
+        ////////////////////////////////////////////////////////////
+        public Vector2i Size => new Vector2i(Width, Height);
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Provide a string describing the object
         /// </summary>
         /// <returns>String description of the object</returns>
@@ -336,6 +352,22 @@ namespace SFML.Graphics
                 return false;
             }
         }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Get the position of the rectangle's top-left corner
+        /// </summary>
+        /// <returns>Position of rectangle</returns>
+        ////////////////////////////////////////////////////////////
+        public Vector2f Position => new Vector2f(Left, Top);
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Get the size of the rectangle
+        /// </summary>
+        /// <returns>Size of rectangle</returns>
+        ////////////////////////////////////////////////////////////
+        public Vector2f Size => new Vector2f(Width, Height);
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -103,6 +103,16 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Tell if the render texture will use sRGB encoding when drawing on it
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public bool IsSrgb
+        {
+            get { return sfRenderTexture_isSrgb(CPointer); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Default view of the render texture
         /// </summary>
         ////////////////////////////////////////////////////////////
@@ -539,6 +549,9 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern Vector2u sfRenderTexture_getSize(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfRenderTexture_isSrgb(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfRenderTexture_setActive(IntPtr CPointer, bool Active);

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -148,6 +148,16 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Tell if the render window will use sRGB encoding when drawing on it
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public bool IsSrgb
+        {
+            get { return sfRenderWindow_isSrgb(CPointer); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Change the title of the window
         /// </summary>
         /// <param name="title">New title</param>
@@ -829,6 +839,9 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern Vector2u sfRenderWindow_getSize(IntPtr CPointer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfRenderWindow_isSrgb(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfRenderWindow_setSize(IntPtr CPointer, Vector2u size);

--- a/src/SFML.Graphics/VertexBuffer.cs
+++ b/src/SFML.Graphics/VertexBuffer.cs
@@ -315,6 +315,29 @@ namespace SFML.Graphics
             }
         }
 
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Draw the vertex buffer to a render target
+        /// </summary>
+        /// <param name="target">Render target to draw to</param>
+        /// <param name="firstVertex">Index of the first vertex to render</param>
+        /// <param name="vertexCount">Number of vertices to render</param>
+        /// <param name="states">Current render states</param>
+        ////////////////////////////////////////////////////////////
+        public void Draw(RenderTarget target, uint firstVertex, uint vertexCount, RenderStates states)
+        {
+            RenderStates.MarshalData marshaledStates = states.Marshal();
+
+            if (target is RenderWindow)
+            {
+                sfRenderWindow_drawVertexBufferRange(( (RenderWindow)target ).CPointer, CPointer, firstVertex, vertexCount, ref marshaledStates);
+            }
+            else if (target is RenderTexture)
+            {
+                sfRenderTexture_drawVertexBufferRange(( (RenderTexture)target ).CPointer, CPointer, firstVertex, vertexCount, ref marshaledStates);
+            }
+        }
+
         #region Imports
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfVertexBuffer_create(uint vertexCount, PrimitiveType type, UsageSpecifier usage);
@@ -362,7 +385,13 @@ namespace SFML.Graphics
         private static extern void sfRenderWindow_drawVertexBuffer(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfRenderWindow_drawVertexBufferRange(IntPtr CPointer, IntPtr VertexBuffer, uint firstVertex, uint vertexCount, ref RenderStates.MarshalData states);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfRenderTexture_drawVertexBuffer(IntPtr CPointer, IntPtr VertexBuffer, ref RenderStates.MarshalData states);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfRenderTexture_drawVertexBufferRange(IntPtr CPointer, IntPtr VertexBuffer, uint firstVertex, uint vertexCount, ref RenderStates.MarshalData states);
         #endregion
     }
 }

--- a/src/SFML.System/Buffer.cs
+++ b/src/SFML.System/Buffer.cs
@@ -34,15 +34,15 @@ namespace SFML.System
         ////////////////////////////////////////////////////////////
         public byte[] GetData()
         {
-            uint size = sfBuffer_getSize(CPointer);
-            IntPtr ptr = sfBuffer_getData(CPointer);
+            var size = sfBuffer_getSize(CPointer);
+            var ptr = sfBuffer_getData(CPointer);
 
             if (ptr == IntPtr.Zero)
             {
                 return Array.Empty<byte>();
             }
 
-            byte[] data = new byte[size];
+            var data = new byte[size];
             Marshal.Copy(ptr, data, 0, (int)size);
 
             return data;

--- a/src/SFML.System/Buffer.cs
+++ b/src/SFML.System/Buffer.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace SFML.System
+{
+    ////////////////////////////////////////////////////////////
+    /// <summary>
+    /// Internal helper class for CSFML's sfBuffer
+    /// </summary>
+    ////////////////////////////////////////////////////////////
+    public class Buffer : ObjectBase
+    {
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Construct the buffer
+        /// </summary>
+        /// <exception cref="LoadingFailedException" />
+        ////////////////////////////////////////////////////////////
+        public Buffer() :
+            base(sfBuffer_create())
+        {
+            if (CPointer == IntPtr.Zero)
+            {
+                throw new LoadingFailedException("buffer");
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Get a copy of the buffer data
+        /// </summary>
+        /// <returns>A byte array containing the buffer data</returns>
+        ////////////////////////////////////////////////////////////
+        public byte[] GetData()
+        {
+            uint size = sfBuffer_getSize(CPointer);
+            IntPtr ptr = sfBuffer_getData(CPointer);
+
+            if (ptr == IntPtr.Zero)
+            {
+                return Array.Empty<byte>();
+            }
+
+            byte[] data = new byte[size];
+            Marshal.Copy(ptr, data, 0, (int)size);
+
+            return data;
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Internal constructor
+        /// </summary>
+        /// <param name="cPointer">Pointer to the object in C library</param>
+        ////////////////////////////////////////////////////////////
+        internal Buffer(IntPtr cPointer) :
+            base(cPointer)
+        {
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Handle the destruction of the object
+        /// </summary>
+        /// <param name="disposing">Is the GC disposing the object, or is it an explicit call?</param>
+        ////////////////////////////////////////////////////////////
+        protected override void Destroy(bool disposing)
+        {
+            sfBuffer_destroy(CPointer);
+        }
+
+        #region Imports
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr sfBuffer_create();
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfBuffer_destroy(IntPtr buffer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern uint sfBuffer_getSize(IntPtr buffer);
+
+        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr sfBuffer_getData(IntPtr buffer);
+        #endregion
+    }
+}

--- a/src/SFML.Window/Context.cs
+++ b/src/SFML.Window/Context.cs
@@ -35,14 +35,38 @@ namespace SFML.Window
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Check whether a given OpenGL extension is available.
+        /// </summary>
+        /// <param name="name">Name of the extension to check for</param>
+        /// <returns>True if available, false if unavailable</returns>
+        ////////////////////////////////////////////////////////////
+        public bool IsExtensionAvailable(string name)
+        {
+            return sfContext_isExtensionAvailable(myThis, name);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Activate or deactivate the context
         /// </summary>
         /// <param name="active">True to activate, false to deactivate</param>
-        /// <returns>true on success, false on failure</returns>
+        /// <returns>True on success, false on failure</returns>
         ////////////////////////////////////////////////////////////
         public bool SetActive(bool active)
         {
             return sfContext_setActive(myThis, active);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Get the address of an OpenGL function.
+        /// </summary>
+        /// <param name="name">Name of the function to get the address of</param>
+        /// <returns>Address of the OpenGL function, <see cref="IntPtr.Zero"/> on failure</returns>
+        ////////////////////////////////////////////////////////////
+        public IntPtr GetFunction(string name)
+        {
+            return sfContext_getFunction(myThis, name);
         }
 
         ////////////////////////////////////////////////////////////
@@ -96,7 +120,13 @@ namespace SFML.Window
         private static extern void sfContext_destroy(IntPtr View);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfContext_isExtensionAvailable(IntPtr View, string name);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfContext_setActive(IntPtr View, bool Active);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr sfContext_getFunction(IntPtr View, string name);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern ContextSettings sfContext_getSettings(IntPtr View);

--- a/src/SFML.Window/Cursor.cs
+++ b/src/SFML.Window/Cursor.cs
@@ -84,6 +84,62 @@ namespace SFML.Window
             /// </summary>
             SizeBottomLeftTopRight,
             /// <summary>
+            /// Left arrow cursor on Linux, same as SizeHorizontal on other platforms
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeLeft,
+            /// <summary>
+            /// Right arrow cursor on Linux, same as SizeHorizontal on other platforms
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeRight,
+            /// <summary>
+            /// Up arrow cursor on Linux, same as SizeVertical on other platforms
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeTop,
+            /// <summary>
+            /// Down arrow cursor on Linux, same as SizeVertical on other platforms
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeBottom,
+            /// <summary>
+            /// Top-left arrow cursor on Linux, same as SizeTopLeftBottomRight on other platforms
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeTopLeft,
+            /// <summary>
+            /// Bottom-right arrow cursor on Linux, same as SizeTopLeftBottomRight on other platforms
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeBottomRight,
+            /// <summary>
+            /// Bottom-left arrow cursor on Linux, same as SizeBottomLeftTopRight on other platforms
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeBottomLeft,
+            /// <summary>
+            /// Top-right arrow cursor on Linux, same as SizeBottomLeftTopRight on other platforms
+            /// Windows: Yes
+            /// Mac OS:  Yes
+            /// Linux:   Yes
+            /// </summary>
+            SizeTopRight,
+            /// <summary>
             /// Combination of SizeHorizontal and SizeVertical
             /// Windows: Yes
             /// Mac OS:  No

--- a/src/SFML.Window/Keyboard.cs
+++ b/src/SFML.Window/Keyboard.cs
@@ -15,6 +15,10 @@ namespace SFML.Window
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Key codes
+        /// 
+        /// The enumerators refer to the "localized" key; i.e. depending
+        /// on the layout set by the operating system, a key can be mapped
+        /// to `Y` or `Z`.
         /// </summary>
         ////////////////////////////////////////////////////////////
         public enum Key
@@ -101,7 +105,7 @@ namespace SFML.Window
             LShift,
             /// <summary>The left Alt key</summary>
             LAlt,
-            /// <summary>The left OS specific key: window (Windows and Linux), apple (MacOS X), ...</summary>
+            /// <summary>The left OS specific key: window (Windows and Linux), apple (macOS), ...</summary>
             LSystem,
             /// <summary>The right Control key</summary>
             RControl,
@@ -109,7 +113,7 @@ namespace SFML.Window
             RShift,
             /// <summary>The right Alt key</summary>
             RAlt,
-            /// <summary>The right OS specific key: window (Windows and Linux), apple (MacOS X), ...</summary>
+            /// <summary>The right OS specific key: window (Windows and Linux), apple (macOS), ...</summary>
             RSystem,
             /// <summary>The Menu key</summary>
             Menu,
@@ -124,13 +128,13 @@ namespace SFML.Window
             /// <summary>The . key</summary>
             Period,
             /// <summary>The ' key</summary>
-            Quote,
+            Apostrophe,
             /// <summary>The / key</summary>
             Slash,
             /// <summary>The \ key</summary>
             Backslash,
             /// <summary>The ~ key</summary>
-            Tilde,
+            Grave,
             /// <summary>The = key</summary>
             Equal,
             /// <summary>The - key</summary>
@@ -228,6 +232,9 @@ namespace SFML.Window
             KeyCount, // Keep last
 
             // Deprecated backwards compatible stuff
+            /// <summary>DEPRECATED: Use Grave</summary>
+            [Obsolete("Replace with Grave")]
+            Tilde = Grave,
             /// <summary>DEPRECATED: Use Hyphen</summary>
             [Obsolete("Replace with Hyphen")]
             Dash = Hyphen,
@@ -242,8 +249,327 @@ namespace SFML.Window
             BackSlash = Backslash,
             /// <summary>DEPRECATED: Use Semicolon</summary>
             [Obsolete("Replace with Semicolon")]
-            SemiColon = Semicolon
+            SemiColon = Semicolon,
+            /// <summary>DEPRECATED: Use Apostrophe</summary>
+            [Obsolete("Replace with Apostrophe")]
+            Quote = Apostrophe
         };
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Scancodes
+        /// 
+        /// The enumerators are bound to a physical key and do not depend on
+        /// the keyboard layout used by the operating system. Usually, the AT-101
+        /// keyboard can be used as reference for the physical position of the keys.
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public enum Scancode
+        {
+            /// <summary>Represents any scancode not present in this enum</summary>
+            Unknown = -1,
+            /// <summary>Keyboard a and A key</summary>
+            A = 0,
+            /// <summary>Keyboard b and B key</summary>
+            B,
+            /// <summary>Keyboard c and C key</summary>
+            C,
+            /// <summary>Keyboard d and D key</summary>
+            D,
+            /// <summary>Keyboard e and E key</summary>
+            E,
+            /// <summary>Keyboard f and F key</summary>
+            F,
+            /// <summary>Keyboard g and G key</summary>
+            G,
+            /// <summary>Keyboard h and H key</summary>
+            H,
+            /// <summary>Keyboard i and I key</summary>
+            I,
+            /// <summary>Keyboard j and J key</summary>
+            J,
+            /// <summary>Keyboard k and K key</summary>
+            K,
+            /// <summary>Keyboard l and L key</summary>
+            L,
+            /// <summary>Keyboard m and M key</summary>
+            M,
+            /// <summary>Keyboard n and N key</summary>
+            N,
+            /// <summary>Keyboard o and O key</summary>
+            O,
+            /// <summary>Keyboard p and P key</summary>
+            P,
+            /// <summary>Keyboard q and Q key</summary>
+            Q,
+            /// <summary>Keyboard r and R key</summary>
+            R,
+            /// <summary>Keyboard s and S key</summary>
+            S,
+            /// <summary>Keyboard t and T key</summary>
+            T,
+            /// <summary>Keyboard u and U key</summary>
+            U,
+            /// <summary>Keyboard v and V key</summary>
+            V,
+            /// <summary>Keyboard w and W key</summary>
+            W,
+            /// <summary>Keyboard x and X key</summary>
+            X,
+            /// <summary>Keyboard y and Y key</summary>
+            Y,
+            /// <summary>Keyboard z and Z key</summary>
+            Z,
+            /// <summary>Keyboard 1 and ! key</summary>
+            Num1,
+            /// <summary>Keyboard 2 and @ key</summary>
+            Num2,
+            /// <summary>Keyboard 3 and # key</summary>
+            Num3,
+            /// <summary>Keyboard 4 and $ key</summary>
+            Num4,
+            /// <summary>Keyboard 5 and % key</summary>
+            Num5,
+            /// <summary>Keyboard 6 and ^ key</summary>
+            Num6,
+            /// <summary>Keyboard 7 and &amp; key</summary>
+            Num7,
+            /// <summary>Keyboard 8 and * key</summary>
+            Num8,
+            /// <summary>Keyboard 9 and ) key</summary>
+            Num9,
+            /// <summary>Keyboard 0 and ) key</summary>
+            Num0,
+            /// <summary>Keyboard Enter/Return key</summary>
+            Enter,
+            /// <summary>Keyboard Escape key</summary>
+            Escape,
+            /// <summary>Keyboard Backspace key</summary>
+            Backspace,
+            /// <summary>Keyboard Tab key</summary>
+            Tab,
+            /// <summary>Keyboard Space key</summary>
+            Space,
+            /// <summary>Keyboard - and _ key</summary>
+            Hyphen,
+            /// <summary>Keyboard = and +</summary>
+            Equal,
+            /// <summary>Keyboard [ and { key</summary>
+            LBracket,
+            /// <summary>Keyboard ] and } key</summary>
+            RBracket,
+            // For US keyboards mapped to key 29 (Microsoft Keyboard Scan Code Specification)
+            // For Non-US keyboards mapped to key 42 (Microsoft Keyboard Scan Code Specification)
+            // Typical language mappings: Belg:£µ` FrCa:<>} Dan:*' Dutch:`´ Fren:µ* Ger:'# Ital:§ù LatAm:[}` Nor:*@ Span:ç} Swed:*' Swiss:$£} UK:~# Brazil:}]
+            /// <summary>Keyboard \ and | key OR various keys for Non-US keyboards</summary>
+            Backslash,
+            /// <summary>Keyboard ; and : key</summary>
+            Semicolon,
+            /// <summary>Keyboard ' and " key</summary>
+            Apostrophe,
+            /// <summary>Keyboard ` and ~ key</summary>
+            Grave,
+            /// <summary>Keyboard , and &lt; key</summary>
+            Comma,
+            /// <summary>Keyboard . and > key</summary>
+            Period,
+            /// <summary>Keyboard / and ? key</summary>
+            Slash,
+            /// <summary>Keyboard F1 key</summary>
+            F1,
+            /// <summary>Keyboard F2 key</summary>
+            F2,
+            /// <summary>Keyboard F3 key</summary>
+            F3,
+            /// <summary>Keyboard F5 key</summary>
+            F4,
+            /// <summary>Keyboard F4 key</summary>
+            F5,
+            /// <summary>Keyboard F6 key</summary>
+            F6,
+            /// <summary>Keyboard F7 key</summary>
+            F7,
+            /// <summary>Keyboard F8 key</summary>
+            F8,
+            /// <summary>Keyboard F9 key</summary>
+            F9,
+            /// <summary>Keyboard F10 key</summary>
+            F10,
+            /// <summary>Keyboard F11 key</summary>
+            F11,
+            /// <summary>Keyboard F12 key</summary>
+            F12,
+            /// <summary>Keyboard F13 key</summary>
+            F13,
+            /// <summary>Keyboard F14 key</summary>
+            F14,
+            /// <summary>Keyboard F15 key</summary>
+            F15,
+            /// <summary>Keyboard F16 key</summary>
+            F16,
+            /// <summary>Keyboard F17 key</summary>
+            F17,
+            /// <summary>Keyboard F18 key</summary>
+            F18,
+            /// <summary>Keyboard F19 key</summary>
+            F19,
+            /// <summary>Keyboard F20 key</summary>
+            F20,
+            /// <summary>Keyboard F21 key</summary>
+            F21,
+            /// <summary>Keyboard F22 key</summary>
+            F22,
+            /// <summary>Keyboard F23 key</summary>
+            F23,
+            /// <summary>Keyboard F24 key</summary>
+            F24,
+            /// <summary>Keyboard Caps %Lock key</summary>
+            CapsLock,
+            /// <summary>Keyboard Print Screen key</summary>
+            PrintScreen,
+            /// <summary>Keyboard Scroll %Lock key</summary>
+            ScrollLock,
+            /// <summary>Keyboard Pause key</summary>
+            Pause,
+            /// <summary>Keyboard Insert key</summary>
+            Insert,
+            /// <summary>Keyboard Home key</summary>
+            Home,
+            /// <summary>Keyboard Page Up key</summary>
+            PageUp,
+            /// <summary>Keyboard Delete Forward key</summary>
+            Delete,
+            /// <summary>Keyboard End key</summary>
+            End,
+            /// <summary>Keyboard Page Down key</summary>
+            PageDown,
+            /// <summary>Keyboard Right Arrow key</summary>
+            Right,
+            /// <summary>Keyboard Left Arrow key</summary>
+            Left,
+            /// <summary>Keyboard Down Arrow key</summary>
+            Down,
+            /// <summary>Keyboard Up Arrow key</summary>
+            Up,
+            /// <summary>Keypad Num %Lock and Clear key</summary>
+            NumLock,
+            /// <summary>Keypad / key</summary>
+            NumpadDivide,
+            /// <summary>Keypad * key</summary>
+            NumpadMultiply,
+            /// <summary>Keypad - key</summary>
+            NumpadMinus,
+            /// <summary>Keypad + key</summary>
+            NumpadPlus,
+            /// <summary>keypad = key</summary>
+            NumpadEqual,
+            /// <summary>Keypad Enter/Return key</summary>
+            NumpadEnter,
+            /// <summary>Keypad . and Delete key</summary>
+            NumpadDecimal,
+            /// <summary>Keypad 1 and End key</summary>
+            Numpad1,
+            /// <summary>Keypad 2 and Down Arrow key</summary>
+            Numpad2,
+            /// <summary>Keypad 3 and Page Down key</summary>
+            Numpad3,
+            /// <summary>Keypad 4 and Left Arrow key</summary>
+            Numpad4,
+            /// <summary>Keypad 5 key</summary>
+            Numpad5,
+            /// <summary>Keypad 6 and Right Arrow key</summary>
+            Numpad6,
+            /// <summary>Keypad 7 and Home key</summary>
+            Numpad7,
+            /// <summary>Keypad 8 and Up Arrow key</summary>
+            Numpad8,
+            /// <summary>Keypad 9 and Page Up key</summary>
+            Numpad9,
+            /// <summary>Keypad 0 and Insert key</summary>
+            Numpad0,
+            // For US keyboards doesn't exist
+            // For Non-US keyboards mapped to key 45 (Microsoft Keyboard Scan Code Specification)
+            // Typical language mappings: Belg:<\> FrCa:«°» Dan:<\> Dutch:]|[ Fren:<> Ger:<|> Ital:<> LatAm:<> Nor:<> Span:<> Swed:<|> Swiss:<\> UK:\| Brazil: \|.
+            /// <summary>Keyboard Non-US \ and | key</summary>
+            NonUsBackslash,
+            /// <summary>Keyboard Application key</summary>
+            Application,
+            /// <summary>Keyboard Execute key</summary>
+            Execute,
+            /// <summary>Keyboard Mode Change key</summary>
+            ModeChange,
+            /// <summary>Keyboard Help key</summary>
+            Help,
+            /// <summary>Keyboard Menu key</summary>
+            Menu,
+            /// <summary>Keyboard Select key</summary>
+            Select,
+            /// <summary>Keyboard Redo key</summary>
+            Redo,
+            /// <summary>Keyboard Undo key</summary>
+            Undo,
+            /// <summary>Keyboard Cut key</summary>
+            Cut,
+            /// <summary>Keyboard Copy key</summary>
+            Copy,
+            /// <summary>Keyboard Paste key</summary>
+            Paste,
+            /// <summary>Keyboard Volume Mute key</summary>
+            VolumeMute,
+            /// <summary>Keyboard Volume Up key</summary>
+            VolumeUp,
+            /// <summary>Keyboard Volume Down key</summary>
+            VolumeDown,
+            /// <summary>Keyboard Media Play Pause key</summary>
+            MediaPlayPause,
+            /// <summary>Keyboard Media Stop key</summary>
+            MediaStop,
+            /// <summary>Keyboard Media Next Track key</summary>
+            MediaNextTrack,
+            /// <summary>Keyboard Media Previous Track key</summary>
+            MediaPreviousTrack,
+            /// <summary>Keyboard Left Control key</summary>
+            LControl,
+            /// <summary>Keyboard Left Shift key</summary>
+            LShift,
+            /// <summary>Keyboard Left Alt key</summary>
+            LAlt,
+            /// <summary>Keyboard Left System key</summary>
+            LSystem,
+            /// <summary>Keyboard Right Control key</summary>
+            RControl,
+            /// <summary>Keyboard Right Shift key</summary>
+            RShift,
+            /// <summary>Keyboard Right Alt key</summary>
+            RAlt,
+            /// <summary>Keyboard Right System key</summary>
+            RSystem,
+            /// <summary>Keyboard Back key</summary>
+            Back,
+            /// <summary>Keyboard Forward key</summary>
+            Forward,
+            /// <summary>Keyboard Refresh key</summary>
+            Refresh,
+            /// <summary>Keyboard Stop key</summary>
+            Stop,
+            /// <summary>Keyboard Search key</summary>
+            Search,
+            /// <summary>Keyboard Favorites key</summary>
+            Favorites,
+            /// <summary>Keyboard Home Page key</summary>
+            HomePage,
+            /// <summary>Keyboard Launch Application 1 key</summary>
+            LaunchApplication1,
+            /// <summary>Keyboard Launch Application 2 key</summary>
+            LaunchApplication2,
+            /// <summary>Keyboard Launch Mail key</summary>
+            LaunchMail,
+            /// <summary>Keyboard Launch Media Select key</summary>
+            LaunchMediaSelect,
+
+            /// <summary>Keep last -- the total number of scancodes</summary>
+            ScancodeCount
+        }
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -259,7 +585,55 @@ namespace SFML.Window
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Enable/Disable visibility of the virtual keyboard
+        /// Check if a key is pressed
+        /// </summary>
+        /// <param name="code">Scancode to check</param>
+        /// <returns>True if the physical key is pressed, false otherwise</returns>
+        ////////////////////////////////////////////////////////////
+        public static bool IsScancodePressed(Scancode code)
+        {
+            return sfKeyboard_isScancodePressed(code);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Localize a physical key to a logical one
+        /// </summary>
+        /// <param name="code">Scancode to localize</param>
+        /// <returns>
+        /// The key corresponding to the scancode under the current
+        /// keyboard layout used by the operating system, or
+        /// <see cref="Key.Unknown"/> when the scancode cannot be mapped
+        /// to a <see cref="Key"/>.
+        /// </returns>
+        ////////////////////////////////////////////////////////////
+        public static Key Localize(Scancode code)
+        {
+            return sfKeyboard_localize(code);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Identify the physical key corresponding to a logical one
+        /// </summary>
+        /// <param name="key">Key to "delocalize"</param>
+        /// <returns>
+        /// The scancode corresponding to the key under the current
+        /// keyboard layout used by the operating system, or
+        /// <see cref="Scancode.Unknown"/> when the key cannot be mapped
+        /// to a <see cref="Scancode"/>.
+        /// </returns>
+        ////////////////////////////////////////////////////////////
+        public static Scancode Delocalize(Key key)
+        {
+            return sfKeyboard_delocalize(key);
+        }
+
+        // TODO Implement GetDescription
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Show or hide the virtual keyboard.
         /// </summary>
         /// <remarks>Applicable only on Android and iOS</remarks>
         /// <param name="visible">Whether to make the virtual keyboard visible (true) or not (false)</param>
@@ -272,6 +646,17 @@ namespace SFML.Window
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfKeyboard_isKeyPressed(Key Key);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfKeyboard_isScancodePressed(Scancode code);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern Key sfKeyboard_localize(Scancode code);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern Scancode sfKeyboard_delocalize(Key key);
+
+        // TODO Import sfKeyboard_getDescription
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfKeyboard_setVirtualKeyboardVisible(bool visible);

--- a/src/SFML.Window/Vulkan.cs
+++ b/src/SFML.Window/Vulkan.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+using SFML.System;
+
+namespace SFML.Window
+{
+    /// <summary>Vulkan helper functions</summary>
+    public static class Vulkan
+    {
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Tell whether or not the system supports Vulkan
+        ///
+        /// This function should always be called before using
+        /// the Vulkan features. If it returns false, then
+        /// any attempt to use Vulkan will fail.
+        /// 
+        /// If only compute is required, set <paramref name="requireGraphics"/>
+        /// to false to skip checking for the extensions necessary
+        /// for graphics rendering.
+        /// </summary>
+        /// <param name="requireGraphics"> True to skip checking for graphics extensions, false otherwise </param>
+        /// <returns>True if Vulkan is supported, false otherwise</returns>
+        ////////////////////////////////////////////////////////////
+        public static bool IsAvailable(bool requireGraphics = true) => sfVulkan_isAvailable(requireGraphics);
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Get the address of a Vulkan function
+        /// </summary>
+        /// <param name="name"> Name of the function to get the address of </param>
+        /// <returns>Address of the Vulkan function, <see cref="IntPtr.Zero"/> on failure</returns>
+        ////////////////////////////////////////////////////////////
+        public static IntPtr GetFunction(string name) => sfVulkan_getFunction(name);
+
+        // TODO: Implement GetGraphicsRequiredInstanceExtensions
+
+        #region Imports
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfVulkan_isAvailable(bool requireGraphics);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr sfVulkan_getFunction(string name);
+
+        // TODO: Import sfVulkan_getGraphicsRequiredInstanceExtensions
+        #endregion
+    }
+}

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -8,38 +8,10 @@ namespace SFML.Window
 {
     ////////////////////////////////////////////////////////////
     /// <summary>
-    /// Enumeration of window creation styles
+    /// Window that serves as a target for OpenGL rendering
     /// </summary>
     ////////////////////////////////////////////////////////////
-    [Flags]
-    public enum Styles
-    {
-        /// <summary>No border / title bar (this flag and all others are mutually exclusive)</summary>
-        None = 0,
-
-        /// <summary>Title bar + fixed border</summary>
-        Titlebar = 1 << 0,
-
-        /// <summary>Titlebar + resizable border + maximize button</summary>
-        Resize = 1 << 1,
-
-        /// <summary>Titlebar + close button</summary>
-        Close = 1 << 2,
-
-        /// <summary>Fullscreen mode (this flag and all others are mutually exclusive))</summary>
-        Fullscreen = 1 << 3,
-
-        /// <summary>Default window style (titlebar + resize + close)</summary>
-        Default = Titlebar | Resize | Close
-    }
-
-    ////////////////////////////////////////////////////////////
-    /// <summary>
-    /// Window is a rendering window ; it can create a new window
-    /// or connect to an existing one
-    /// </summary>
-    ////////////////////////////////////////////////////////////
-    public class Window : ObjectBase
+    public class Window : WindowBase
     {
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -121,7 +93,7 @@ namespace SFML.Window
         /// </summary>
         /// <returns>True if the window is opened</returns>
         ////////////////////////////////////////////////////////////
-        public virtual bool IsOpen
+        public override bool IsOpen
         {
             get { return sfWindow_isOpen(CPointer); }
         }
@@ -133,7 +105,7 @@ namespace SFML.Window
         /// Create to recreate the window
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public virtual void Close()
+        public override void Close()
         {
             sfWindow_close(CPointer);
         }
@@ -163,7 +135,7 @@ namespace SFML.Window
         /// Position of the window
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public virtual Vector2i Position
+        public override Vector2i Position
         {
             get { return sfWindow_getPosition(CPointer); }
             set { sfWindow_setPosition(CPointer, value); }
@@ -174,7 +146,7 @@ namespace SFML.Window
         /// Size of the rendering region of the window
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public virtual Vector2u Size
+        public override Vector2u Size
         {
             get { return sfWindow_getSize(CPointer); }
             set { sfWindow_setSize(CPointer, value); }
@@ -186,7 +158,7 @@ namespace SFML.Window
         /// </summary>
         /// <param name="title">New title</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetTitle(string title)
+        public override void SetTitle(string title)
         {
             // Copy the title to a null-terminated UTF-32 byte array
             byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
@@ -208,7 +180,7 @@ namespace SFML.Window
         /// <param name="height">Icon's height, in pixels</param>
         /// <param name="pixels">Array of pixels, format must be RGBA 32 bits</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetIcon(uint width, uint height, byte[] pixels)
+        public override void SetIcon(uint width, uint height, byte[] pixels)
         {
             unsafe
             {
@@ -225,7 +197,7 @@ namespace SFML.Window
         /// </summary>
         /// <param name="visible">True to show the window, false to hide it</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetVisible(bool visible)
+        public override void SetVisible(bool visible)
         {
             sfWindow_setVisible(CPointer, visible);
         }
@@ -236,7 +208,7 @@ namespace SFML.Window
         /// </summary>
         /// <param name="show">True to show, false to hide</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetMouseCursorVisible(bool show)
+        public override void SetMouseCursorVisible(bool show)
         {
             sfWindow_setMouseCursorVisible(CPointer, show);
         }
@@ -256,7 +228,7 @@ namespace SFML.Window
         /// cursor).
         /// </remarks>
         ////////////////////////////////////////////////////////////
-        public virtual void SetMouseCursorGrabbed(bool grabbed)
+        public override void SetMouseCursorGrabbed(bool grabbed)
         {
             sfWindow_setMouseCursorGrabbed(CPointer, grabbed);
         }
@@ -267,7 +239,7 @@ namespace SFML.Window
         /// </summary>
         /// <param name="cursor">Native system cursor type to display</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetMouseCursor(Cursor cursor)
+        public override void SetMouseCursor(Cursor cursor)
         {
             sfWindow_setMouseCursor(CPointer, cursor.CPointer);
         }
@@ -290,7 +262,7 @@ namespace SFML.Window
         /// </summary>
         /// <param name="enable">True to enable, false to disable</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetKeyRepeatEnabled(bool enable)
+        public override void SetKeyRepeatEnabled(bool enable)
         {
             sfWindow_setKeyRepeatEnabled(CPointer, enable);
         }
@@ -338,7 +310,7 @@ namespace SFML.Window
         /// </summary>
         /// <param name="threshold">New threshold, in range [0, 100]</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetJoystickThreshold(float threshold)
+        public override void SetJoystickThreshold(float threshold)
         {
             sfWindow_setJoystickThreshold(CPointer, threshold);
         }
@@ -348,38 +320,9 @@ namespace SFML.Window
         /// OS-specific handle of the window
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public virtual IntPtr SystemHandle
+        public override IntPtr SystemHandle
         {
             get { return sfWindow_getSystemHandle(CPointer); }
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Wait for a new event and dispatch it to the corresponding
-        /// event handler
-        /// </summary>
-        ////////////////////////////////////////////////////////////
-        public void WaitAndDispatchEvents()
-        {
-            Event e;
-            if (WaitEvent(out e))
-            {
-                CallEventHandler(e);
-            }
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Call the event handlers for each pending event
-        /// </summary>
-        ////////////////////////////////////////////////////////////
-        public void DispatchEvents()
-        {
-            Event e;
-            while (PollEvent(out e))
-            {
-                CallEventHandler(e);
-            }
         }
 
         ////////////////////////////////////////////////////////////
@@ -388,7 +331,7 @@ namespace SFML.Window
         /// foreground window
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public virtual void RequestFocus()
+        public override void RequestFocus()
         {
             sfWindow_requestFocus(CPointer);
         }
@@ -399,7 +342,7 @@ namespace SFML.Window
         /// </summary>
         /// <returns>True if the window has focus, false otherwise</returns>
         ////////////////////////////////////////////////////////////
-        public virtual bool HasFocus()
+        public override bool HasFocus()
         {
             return sfWindow_hasFocus(CPointer);
         }
@@ -426,7 +369,7 @@ namespace SFML.Window
         /// <param name="dummy">Internal hack :)</param>
         ////////////////////////////////////////////////////////////
         protected Window(IntPtr cPointer, int dummy) :
-            base(cPointer)
+            base(cPointer, 0)
         {
             // TODO : find a cleaner way of separating this constructor from Window(IntPtr handle)
         }
@@ -438,7 +381,7 @@ namespace SFML.Window
         /// <param name="eventToFill">Variable to fill with the raw pointer to the event structure</param>
         /// <returns>True if there was an event, false otherwise</returns>
         ////////////////////////////////////////////////////////////
-        protected virtual bool PollEvent(out Event eventToFill)
+        protected override bool PollEvent(out Event eventToFill)
         {
             return sfWindow_pollEvent(CPointer, out eventToFill);
         }
@@ -450,49 +393,9 @@ namespace SFML.Window
         /// <param name="eventToFill">Variable to fill with the raw pointer to the event structure</param>
         /// <returns>False if any error occured</returns>
         ////////////////////////////////////////////////////////////
-        protected virtual bool WaitEvent(out Event eventToFill)
+        protected override bool WaitEvent(out Event eventToFill)
         {
             return sfWindow_waitEvent(CPointer, out eventToFill);
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Internal function to get the mouse position relative to the window.
-        /// This function is protected because it is called by another class of
-        /// another module, it is not meant to be called by users.
-        /// </summary>
-        /// <returns>Relative mouse position</returns>
-        ////////////////////////////////////////////////////////////
-        protected internal virtual Vector2i InternalGetMousePosition()
-        {
-            return sfMouse_getPosition(CPointer);
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Internal function to set the mouse position relative to the window.
-        /// This function is protected because it is called by another class of
-        /// another module, it is not meant to be called by users.
-        /// </summary>
-        /// <param name="position">Relative mouse position</param>
-        ////////////////////////////////////////////////////////////
-        protected internal virtual void InternalSetMousePosition(Vector2i position)
-        {
-            sfMouse_setPosition(position, CPointer);
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Internal function to get the touch position relative to the window.
-        /// This function is protected because it is called by another class of
-        /// another module, it is not meant to be called by users.
-        /// </summary>
-        /// <param name="Finger">Finger index</param>
-        /// <returns>Relative touch position</returns>
-        ////////////////////////////////////////////////////////////
-        protected internal virtual Vector2i InternalGetTouchPosition(uint Finger)
-        {
-            return sfTouch_getPosition(Finger, CPointer);
         }
 
         ////////////////////////////////////////////////////////////
@@ -505,279 +408,6 @@ namespace SFML.Window
         {
             sfWindow_destroy(CPointer);
         }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Call the event handler for the given event
-        /// </summary>
-        /// <param name="e">Event to dispatch</param>
-        ////////////////////////////////////////////////////////////
-        private void CallEventHandler(Event e)
-        {
-            switch (e.Type)
-            {
-                case EventType.Closed:
-                    if (Closed != null)
-                    {
-                        Closed(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.GainedFocus:
-                    if (GainedFocus != null)
-                    {
-                        GainedFocus(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.JoystickButtonPressed:
-                    if (JoystickButtonPressed != null)
-                    {
-                        JoystickButtonPressed(this, new JoystickButtonEventArgs(e.JoystickButton));
-                    }
-
-                    break;
-
-                case EventType.JoystickButtonReleased:
-                    if (JoystickButtonReleased != null)
-                    {
-                        JoystickButtonReleased(this, new JoystickButtonEventArgs(e.JoystickButton));
-                    }
-
-                    break;
-
-                case EventType.JoystickMoved:
-                    if (JoystickMoved != null)
-                    {
-                        JoystickMoved(this, new JoystickMoveEventArgs(e.JoystickMove));
-                    }
-
-                    break;
-
-                case EventType.JoystickConnected:
-                    if (JoystickConnected != null)
-                    {
-                        JoystickConnected(this, new JoystickConnectEventArgs(e.JoystickConnect));
-                    }
-
-                    break;
-
-                case EventType.JoystickDisconnected:
-                    if (JoystickDisconnected != null)
-                    {
-                        JoystickDisconnected(this, new JoystickConnectEventArgs(e.JoystickConnect));
-                    }
-
-                    break;
-
-                case EventType.KeyPressed:
-                    if (KeyPressed != null)
-                    {
-                        KeyPressed(this, new KeyEventArgs(e.Key));
-                    }
-
-                    break;
-
-                case EventType.KeyReleased:
-                    if (KeyReleased != null)
-                    {
-                        KeyReleased(this, new KeyEventArgs(e.Key));
-                    }
-
-                    break;
-
-                case EventType.LostFocus:
-                    if (LostFocus != null)
-                    {
-                        LostFocus(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.MouseButtonPressed:
-                    if (MouseButtonPressed != null)
-                    {
-                        MouseButtonPressed(this, new MouseButtonEventArgs(e.MouseButton));
-                    }
-
-                    break;
-
-                case EventType.MouseButtonReleased:
-                    if (MouseButtonReleased != null)
-                    {
-                        MouseButtonReleased(this, new MouseButtonEventArgs(e.MouseButton));
-                    }
-
-                    break;
-
-                case EventType.MouseEntered:
-                    if (MouseEntered != null)
-                    {
-                        MouseEntered(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.MouseLeft:
-                    if (MouseLeft != null)
-                    {
-                        MouseLeft(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.MouseMoved:
-                    if (MouseMoved != null)
-                    {
-                        MouseMoved(this, new MouseMoveEventArgs(e.MouseMove));
-                    }
-
-                    break;
-
-// Disable CS0618 (Obselete Warning).  This Event will be removed in SFML.NET 3.0, but should remain supported until then.
-#pragma warning disable CS0618
-                case EventType.MouseWheelMoved:
-                    if (MouseWheelMoved != null)
-                    {
-                        MouseWheelMoved(this, new MouseWheelEventArgs(e.MouseWheel));
-                    }
-
-                    break;
-// restore CS0618
-#pragma warning restore CS0618
-
-                case EventType.MouseWheelScrolled:
-                    if (MouseWheelScrolled != null)
-                    {
-                        MouseWheelScrolled(this, new MouseWheelScrollEventArgs(e.MouseWheelScroll));
-                    }
-
-                    break;
-
-                case EventType.Resized:
-                    if (Resized != null)
-                    {
-                        Resized(this, new SizeEventArgs(e.Size));
-                    }
-
-                    break;
-
-                case EventType.TextEntered:
-                    if (TextEntered != null)
-                    {
-                        TextEntered(this, new TextEventArgs(e.Text));
-                    }
-
-                    break;
-
-                case EventType.TouchBegan:
-                    if (TouchBegan != null)
-                    {
-                        TouchBegan(this, new TouchEventArgs(e.Touch));
-                    }
-
-                    break;
-
-                case EventType.TouchMoved:
-                    if (TouchMoved != null)
-                    {
-                        TouchMoved(this, new TouchEventArgs(e.Touch));
-                    }
-
-                    break;
-
-                case EventType.TouchEnded:
-                    if (TouchEnded != null)
-                    {
-                        TouchEnded(this, new TouchEventArgs(e.Touch));
-                    }
-
-                    break;
-
-                case EventType.SensorChanged:
-                    if (SensorChanged != null)
-                    {
-                        SensorChanged(this, new SensorEventArgs(e.Sensor));
-                    }
-
-                    break;
-
-                default:
-                    break;
-            }
-        }
-
-        /// <summary>Event handler for the Closed event</summary>
-        public event EventHandler Closed = null;
-
-        /// <summary>Event handler for the Resized event</summary>
-        public event EventHandler<SizeEventArgs> Resized = null;
-
-        /// <summary>Event handler for the LostFocus event</summary>
-        public event EventHandler LostFocus = null;
-
-        /// <summary>Event handler for the GainedFocus event</summary>
-        public event EventHandler GainedFocus = null;
-
-        /// <summary>Event handler for the TextEntered event</summary>
-        public event EventHandler<TextEventArgs> TextEntered = null;
-
-        /// <summary>Event handler for the KeyPressed event</summary>
-        public event EventHandler<KeyEventArgs> KeyPressed = null;
-
-        /// <summary>Event handler for the KeyReleased event</summary>
-        public event EventHandler<KeyEventArgs> KeyReleased = null;
-
-        /// <summary>Event handler for the MouseWheelMoved event</summary>
-        [Obsolete("Use MouseWheelScrolled")]
-        public event EventHandler<MouseWheelEventArgs> MouseWheelMoved = null;
-
-        /// <summary>Event handler for the MouseWheelScrolled event</summary>
-        public event EventHandler<MouseWheelScrollEventArgs> MouseWheelScrolled = null;
-
-        /// <summary>Event handler for the MouseButtonPressed event</summary>
-        public event EventHandler<MouseButtonEventArgs> MouseButtonPressed = null;
-
-        /// <summary>Event handler for the MouseButtonReleased event</summary>
-        public event EventHandler<MouseButtonEventArgs> MouseButtonReleased = null;
-
-        /// <summary>Event handler for the MouseMoved event</summary>
-        public event EventHandler<MouseMoveEventArgs> MouseMoved = null;
-
-        /// <summary>Event handler for the MouseEntered event</summary>
-        public event EventHandler MouseEntered = null;
-
-        /// <summary>Event handler for the MouseLeft event</summary>
-        public event EventHandler MouseLeft = null;
-
-        /// <summary>Event handler for the JoystickButtonPressed event</summary>
-        public event EventHandler<JoystickButtonEventArgs> JoystickButtonPressed = null;
-
-        /// <summary>Event handler for the JoystickButtonReleased event</summary>
-        public event EventHandler<JoystickButtonEventArgs> JoystickButtonReleased = null;
-
-        /// <summary>Event handler for the JoystickMoved event</summary>
-        public event EventHandler<JoystickMoveEventArgs> JoystickMoved = null;
-
-        /// <summary>Event handler for the JoystickConnected event</summary>
-        public event EventHandler<JoystickConnectEventArgs> JoystickConnected = null;
-
-        /// <summary>Event handler for the JoystickDisconnected event</summary>
-        public event EventHandler<JoystickConnectEventArgs> JoystickDisconnected = null;
-
-        /// <summary>Event handler for the TouchBegan event</summary>
-        public event EventHandler<TouchEventArgs> TouchBegan = null;
-
-        /// <summary>Event handler for the TouchMoved event</summary>
-        public event EventHandler<TouchEventArgs> TouchMoved = null;
-
-        /// <summary>Event handler for the TouchEnded event</summary>
-        public event EventHandler<TouchEventArgs> TouchEnded = null;
-
-        /// <summary>Event handler for the SensorChanged event</summary>
-        public event EventHandler<SensorEventArgs> SensorChanged = null;
 
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
@@ -869,15 +499,6 @@ namespace SFML.Window
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfWindow_hasFocus(IntPtr CPointer);
-
-        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern Vector2i sfMouse_getPosition(IntPtr CPointer);
-
-        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern void sfMouse_setPosition(Vector2i position, IntPtr CPointer);
-
-        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern Vector2i sfTouch_getPosition(uint Finger, IntPtr RelativeTo);
         #endregion
     }
 }

--- a/src/SFML.Window/WindowBase.cs
+++ b/src/SFML.Window/WindowBase.cs
@@ -1,0 +1,797 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+using SFML.System;
+
+namespace SFML.Window
+{
+    ////////////////////////////////////////////////////////////
+    /// <summary>
+    /// Enumeration of window creation styles
+    /// </summary>
+    ////////////////////////////////////////////////////////////
+    [Flags]
+    public enum Styles
+    {
+        /// <summary>No border / title bar (this flag and all others are mutually exclusive)</summary>
+        None = 0,
+
+        /// <summary>Title bar + fixed border</summary>
+        Titlebar = 1 << 0,
+
+        /// <summary>Titlebar + resizable border + maximize button</summary>
+        Resize = 1 << 1,
+
+        /// <summary>Titlebar + close button</summary>
+        Close = 1 << 2,
+
+        /// <summary>Fullscreen mode (this flag and all others are mutually exclusive))</summary>
+        Fullscreen = 1 << 3,
+
+        /// <summary>Default window style (titlebar + resize + close)</summary>
+        Default = Titlebar | Resize | Close
+    }
+
+
+    ////////////////////////////////////////////////////////////
+    /// <summary>
+    /// Window that serves as a base for other windows
+    /// </summary>
+    ////////////////////////////////////////////////////////////
+    public class WindowBase : ObjectBase
+    {
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Create the window with default style and creation settings
+        /// </summary>
+        /// <param name="mode">Video mode to use</param>
+        /// <param name="title">Title of the window</param>
+        ////////////////////////////////////////////////////////////
+        public WindowBase(VideoMode mode, string title) :
+            this(mode, title, Styles.Default)
+        {
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Create the window with default creation settings
+        /// </summary>
+        /// <param name="mode">Video mode to use</param>
+        /// <param name="title">Title of the window</param>
+        /// <param name="style">Window style (Resize | Close by default)</param>
+        ////////////////////////////////////////////////////////////
+        public WindowBase(VideoMode mode, string title, Styles style) :
+            base(IntPtr.Zero)
+        {
+            // Copy the title to a null-terminated UTF-32 byte array
+            byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
+
+            unsafe
+            {
+                fixed (byte* titlePtr = titleAsUtf32)
+                {
+                    CPointer = sfWindowBase_createUnicode(mode, (IntPtr)titlePtr, style);
+                }
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Create the window from an existing control
+        /// </summary>
+        /// <param name="Handle">Platform-specific handle of the control</param>
+        ////////////////////////////////////////////////////////////
+        public WindowBase(IntPtr Handle) :
+            base(sfWindowBase_createFromHandle(Handle))
+        {
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Tell whether or not the window is opened (ie. has been created).
+        /// Note that a hidden window (Show(false))
+        /// will still return true
+        /// </summary>
+        /// <returns>True if the window is opened</returns>
+        ////////////////////////////////////////////////////////////
+        public virtual bool IsOpen
+        {
+            get { return sfWindowBase_isOpen(CPointer); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Close (destroy) the window.
+        /// The Window instance remains valid and you can call
+        /// Create to recreate the window
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public virtual void Close()
+        {
+            sfWindowBase_close(CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Position of the window
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public virtual Vector2i Position
+        {
+            get { return sfWindowBase_getPosition(CPointer); }
+            set { sfWindowBase_setPosition(CPointer, value); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Size of the rendering region of the window
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public virtual Vector2u Size
+        {
+            get { return sfWindowBase_getSize(CPointer); }
+            set { sfWindowBase_setSize(CPointer, value); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Change the title of the window
+        /// </summary>
+        /// <param name="title">New title</param>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetTitle(string title)
+        {
+            // Copy the title to a null-terminated UTF-32 byte array
+            byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
+
+            unsafe
+            {
+                fixed (byte* titlePtr = titleAsUtf32)
+                {
+                    sfWindowBase_setUnicodeTitle(CPointer, (IntPtr)titlePtr);
+                }
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Change the window's icon
+        /// </summary>
+        /// <param name="width">Icon's width, in pixels</param>
+        /// <param name="height">Icon's height, in pixels</param>
+        /// <param name="pixels">Array of pixels, format must be RGBA 32 bits</param>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetIcon(uint width, uint height, byte[] pixels)
+        {
+            unsafe
+            {
+                fixed (byte* PixelsPtr = pixels)
+                {
+                    sfWindowBase_setIcon(CPointer, width, height, PixelsPtr);
+                }
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Show or hide the window
+        /// </summary>
+        /// <param name="visible">True to show the window, false to hide it</param>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetVisible(bool visible)
+        {
+            sfWindowBase_setVisible(CPointer, visible);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Show or hide the mouse cursor
+        /// </summary>
+        /// <param name="show">True to show, false to hide</param>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetMouseCursorVisible(bool show)
+        {
+            sfWindowBase_setMouseCursorVisible(CPointer, show);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Grab or release the mouse cursor
+        /// </summary>
+        /// <param name="grabbed">True to grab, false to release</param>
+        /// 
+        /// <remarks>
+        /// If set, grabs the mouse cursor inside this window's client
+        /// area so it may no longer be moved outside its bounds.
+        /// Note that grabbing is only active while the window has
+        /// focus and calling this function for fullscreen windows
+        /// won't have any effect (fullscreen windows always grab the
+        /// cursor).
+        /// </remarks>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetMouseCursorGrabbed(bool grabbed)
+        {
+            sfWindowBase_setMouseCursorGrabbed(CPointer, grabbed);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Set the displayed cursor to a native system cursor
+        /// 
+        /// Upon window creation, the arrow cursor is used by default.
+        /// </summary>
+        /// <param name="cursor">Native system cursor type to display</param>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetMouseCursor(Cursor cursor)
+        {
+            sfWindowBase_setMouseCursor(CPointer, cursor.CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Enable or disable automatic key-repeat.
+        /// 
+        /// If key repeat is enabled, you will receive repeated
+        /// <see cref="KeyPressed"/> events while keeping a key pressed. If it is
+        /// disabled, you will only get a single event when the key is pressed.
+        /// 
+        /// Automatic key-repeat is enabled by default
+        /// </summary>
+        /// <param name="enable">True to enable, false to disable</param>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetKeyRepeatEnabled(bool enable)
+        {
+            sfWindowBase_setKeyRepeatEnabled(CPointer, enable);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Change the joystick threshold, ie. the value below which
+        /// no move event will be generated
+        /// </summary>
+        /// <param name="threshold">New threshold, in range [0, 100]</param>
+        ////////////////////////////////////////////////////////////
+        public virtual void SetJoystickThreshold(float threshold)
+        {
+            sfWindowBase_setJoystickThreshold(CPointer, threshold);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// OS-specific handle of the window
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public virtual IntPtr SystemHandle
+        {
+            get { return sfWindowBase_getSystemHandle(CPointer); }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Wait for a new event and dispatch it to the corresponding
+        /// event handler
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public void WaitAndDispatchEvents()
+        {
+            Event e;
+            if (WaitEvent(out e))
+            {
+                CallEventHandler(e);
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Call the event handlers for each pending event
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public void DispatchEvents()
+        {
+            Event e;
+            while (PollEvent(out e))
+            {
+                CallEventHandler(e);
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Request the current window to be made the active
+        /// foreground window
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        public virtual void RequestFocus()
+        {
+            sfWindowBase_requestFocus(CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Check whether the window has the input focus
+        /// </summary>
+        /// <returns>True if the window has focus, false otherwise</returns>
+        ////////////////////////////////////////////////////////////
+        public virtual bool HasFocus()
+        {
+            return sfWindowBase_hasFocus(CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Create a Vulkan rendering surface
+        /// </summary>
+        /// <param name="vkInstance">Vulkan instance</param>
+        /// <param name="vkSurface">Created surface</param>
+        /// <param name="vkAllocator">Allocator to use</param>
+        /// <returns>True if surface creation was successful, false otherwise</returns>
+        ////////////////////////////////////////////////////////////
+        public virtual bool CreateVulkanSurface(IntPtr vkInstance, out IntPtr vkSurface, IntPtr vkAllocator)
+        {
+            return sfWindowBase_createVulkanSurface(CPointer, vkInstance, out vkSurface, vkAllocator);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Provide a string describing the object
+        /// </summary>
+        /// <returns>String description of the object</returns>
+        ////////////////////////////////////////////////////////////
+        public override string ToString()
+        {
+            return "[WindowBase]" +
+                   " Size(" + Size + ")" +
+                   " Position(" + Position + ")";
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Constructor for derived classes
+        /// </summary>
+        /// <param name="cPointer">Pointer to the internal object in the C API</param>
+        /// <param name="dummy">Internal hack :)</param>
+        ////////////////////////////////////////////////////////////
+        protected WindowBase(IntPtr cPointer, int dummy) :
+            base(cPointer)
+        {
+            // TODO : find a cleaner way of separating this constructor from WindowBase(IntPtr handle)
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Internal function to get the next event (non-blocking)
+        /// </summary>
+        /// <param name="eventToFill">Variable to fill with the raw pointer to the event structure</param>
+        /// <returns>True if there was an event, false otherwise</returns>
+        ////////////////////////////////////////////////////////////
+        protected virtual bool PollEvent(out Event eventToFill)
+        {
+            return sfWindowBase_pollEvent(CPointer, out eventToFill);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Internal function to get the next event (blocking)
+        /// </summary>
+        /// <param name="eventToFill">Variable to fill with the raw pointer to the event structure</param>
+        /// <returns>False if any error occured</returns>
+        ////////////////////////////////////////////////////////////
+        protected virtual bool WaitEvent(out Event eventToFill)
+        {
+            return sfWindowBase_waitEvent(CPointer, out eventToFill);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Internal function to get the mouse position relative to the window.
+        /// This function is protected because it is called by another class of
+        /// another module, it is not meant to be called by users.
+        /// </summary>
+        /// <returns>Relative mouse position</returns>
+        ////////////////////////////////////////////////////////////
+        protected internal virtual Vector2i InternalGetMousePosition()
+        {
+            return sfMouse_getPosition(CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Internal function to set the mouse position relative to the window.
+        /// This function is protected because it is called by another class of
+        /// another module, it is not meant to be called by users.
+        /// </summary>
+        /// <param name="position">Relative mouse position</param>
+        ////////////////////////////////////////////////////////////
+        protected internal virtual void InternalSetMousePosition(Vector2i position)
+        {
+            sfMouse_setPosition(position, CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Internal function to get the touch position relative to the window.
+        /// This function is protected because it is called by another class of
+        /// another module, it is not meant to be called by users.
+        /// </summary>
+        /// <param name="Finger">Finger index</param>
+        /// <returns>Relative touch position</returns>
+        ////////////////////////////////////////////////////////////
+        protected internal virtual Vector2i InternalGetTouchPosition(uint Finger)
+        {
+            return sfTouch_getPosition(Finger, CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Handle the destruction of the object
+        /// </summary>
+        /// <param name="disposing">Is the GC disposing the object, or is it an explicit call ?</param>
+        ////////////////////////////////////////////////////////////
+        protected override void Destroy(bool disposing)
+        {
+            sfWindowBase_destroy(CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Call the event handler for the given event
+        /// </summary>
+        /// <param name="e">Event to dispatch</param>
+        ////////////////////////////////////////////////////////////
+        private void CallEventHandler(Event e)
+        {
+            switch (e.Type)
+            {
+                case EventType.Closed:
+                    if (Closed != null)
+                    {
+                        Closed(this, EventArgs.Empty);
+                    }
+
+                    break;
+
+                case EventType.GainedFocus:
+                    if (GainedFocus != null)
+                    {
+                        GainedFocus(this, EventArgs.Empty);
+                    }
+
+                    break;
+
+                case EventType.JoystickButtonPressed:
+                    if (JoystickButtonPressed != null)
+                    {
+                        JoystickButtonPressed(this, new JoystickButtonEventArgs(e.JoystickButton));
+                    }
+
+                    break;
+
+                case EventType.JoystickButtonReleased:
+                    if (JoystickButtonReleased != null)
+                    {
+                        JoystickButtonReleased(this, new JoystickButtonEventArgs(e.JoystickButton));
+                    }
+
+                    break;
+
+                case EventType.JoystickMoved:
+                    if (JoystickMoved != null)
+                    {
+                        JoystickMoved(this, new JoystickMoveEventArgs(e.JoystickMove));
+                    }
+
+                    break;
+
+                case EventType.JoystickConnected:
+                    if (JoystickConnected != null)
+                    {
+                        JoystickConnected(this, new JoystickConnectEventArgs(e.JoystickConnect));
+                    }
+
+                    break;
+
+                case EventType.JoystickDisconnected:
+                    if (JoystickDisconnected != null)
+                    {
+                        JoystickDisconnected(this, new JoystickConnectEventArgs(e.JoystickConnect));
+                    }
+
+                    break;
+
+                case EventType.KeyPressed:
+                    if (KeyPressed != null)
+                    {
+                        KeyPressed(this, new KeyEventArgs(e.Key));
+                    }
+
+                    break;
+
+                case EventType.KeyReleased:
+                    if (KeyReleased != null)
+                    {
+                        KeyReleased(this, new KeyEventArgs(e.Key));
+                    }
+
+                    break;
+
+                case EventType.LostFocus:
+                    if (LostFocus != null)
+                    {
+                        LostFocus(this, EventArgs.Empty);
+                    }
+
+                    break;
+
+                case EventType.MouseButtonPressed:
+                    if (MouseButtonPressed != null)
+                    {
+                        MouseButtonPressed(this, new MouseButtonEventArgs(e.MouseButton));
+                    }
+
+                    break;
+
+                case EventType.MouseButtonReleased:
+                    if (MouseButtonReleased != null)
+                    {
+                        MouseButtonReleased(this, new MouseButtonEventArgs(e.MouseButton));
+                    }
+
+                    break;
+
+                case EventType.MouseEntered:
+                    if (MouseEntered != null)
+                    {
+                        MouseEntered(this, EventArgs.Empty);
+                    }
+
+                    break;
+
+                case EventType.MouseLeft:
+                    if (MouseLeft != null)
+                    {
+                        MouseLeft(this, EventArgs.Empty);
+                    }
+
+                    break;
+
+                case EventType.MouseMoved:
+                    if (MouseMoved != null)
+                    {
+                        MouseMoved(this, new MouseMoveEventArgs(e.MouseMove));
+                    }
+
+                    break;
+
+                // Disable CS0618 (Obselete Warning).  This Event will be removed in SFML.NET 3.0, but should remain supported until then.
+#pragma warning disable CS0618
+                case EventType.MouseWheelMoved:
+                    if (MouseWheelMoved != null)
+                    {
+                        MouseWheelMoved(this, new MouseWheelEventArgs(e.MouseWheel));
+                    }
+
+                    break;
+                // restore CS0618
+#pragma warning restore CS0618
+
+                case EventType.MouseWheelScrolled:
+                    if (MouseWheelScrolled != null)
+                    {
+                        MouseWheelScrolled(this, new MouseWheelScrollEventArgs(e.MouseWheelScroll));
+                    }
+
+                    break;
+
+                case EventType.Resized:
+                    if (Resized != null)
+                    {
+                        Resized(this, new SizeEventArgs(e.Size));
+                    }
+
+                    break;
+
+                case EventType.TextEntered:
+                    if (TextEntered != null)
+                    {
+                        TextEntered(this, new TextEventArgs(e.Text));
+                    }
+
+                    break;
+
+                case EventType.TouchBegan:
+                    if (TouchBegan != null)
+                    {
+                        TouchBegan(this, new TouchEventArgs(e.Touch));
+                    }
+
+                    break;
+
+                case EventType.TouchMoved:
+                    if (TouchMoved != null)
+                    {
+                        TouchMoved(this, new TouchEventArgs(e.Touch));
+                    }
+
+                    break;
+
+                case EventType.TouchEnded:
+                    if (TouchEnded != null)
+                    {
+                        TouchEnded(this, new TouchEventArgs(e.Touch));
+                    }
+
+                    break;
+
+                case EventType.SensorChanged:
+                    if (SensorChanged != null)
+                    {
+                        SensorChanged(this, new SensorEventArgs(e.Sensor));
+                    }
+
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        /// <summary>Event handler for the Closed event</summary>
+        public event EventHandler Closed = null;
+
+        /// <summary>Event handler for the Resized event</summary>
+        public event EventHandler<SizeEventArgs> Resized = null;
+
+        /// <summary>Event handler for the LostFocus event</summary>
+        public event EventHandler LostFocus = null;
+
+        /// <summary>Event handler for the GainedFocus event</summary>
+        public event EventHandler GainedFocus = null;
+
+        /// <summary>Event handler for the TextEntered event</summary>
+        public event EventHandler<TextEventArgs> TextEntered = null;
+
+        /// <summary>Event handler for the KeyPressed event</summary>
+        public event EventHandler<KeyEventArgs> KeyPressed = null;
+
+        /// <summary>Event handler for the KeyReleased event</summary>
+        public event EventHandler<KeyEventArgs> KeyReleased = null;
+
+        /// <summary>Event handler for the MouseWheelMoved event</summary>
+        [Obsolete("Use MouseWheelScrolled")]
+        public event EventHandler<MouseWheelEventArgs> MouseWheelMoved = null;
+
+        /// <summary>Event handler for the MouseWheelScrolled event</summary>
+        public event EventHandler<MouseWheelScrollEventArgs> MouseWheelScrolled = null;
+
+        /// <summary>Event handler for the MouseButtonPressed event</summary>
+        public event EventHandler<MouseButtonEventArgs> MouseButtonPressed = null;
+
+        /// <summary>Event handler for the MouseButtonReleased event</summary>
+        public event EventHandler<MouseButtonEventArgs> MouseButtonReleased = null;
+
+        /// <summary>Event handler for the MouseMoved event</summary>
+        public event EventHandler<MouseMoveEventArgs> MouseMoved = null;
+
+        /// <summary>Event handler for the MouseEntered event</summary>
+        public event EventHandler MouseEntered = null;
+
+        /// <summary>Event handler for the MouseLeft event</summary>
+        public event EventHandler MouseLeft = null;
+
+        /// <summary>Event handler for the JoystickButtonPressed event</summary>
+        public event EventHandler<JoystickButtonEventArgs> JoystickButtonPressed = null;
+
+        /// <summary>Event handler for the JoystickButtonReleased event</summary>
+        public event EventHandler<JoystickButtonEventArgs> JoystickButtonReleased = null;
+
+        /// <summary>Event handler for the JoystickMoved event</summary>
+        public event EventHandler<JoystickMoveEventArgs> JoystickMoved = null;
+
+        /// <summary>Event handler for the JoystickConnected event</summary>
+        public event EventHandler<JoystickConnectEventArgs> JoystickConnected = null;
+
+        /// <summary>Event handler for the JoystickDisconnected event</summary>
+        public event EventHandler<JoystickConnectEventArgs> JoystickDisconnected = null;
+
+        /// <summary>Event handler for the TouchBegan event</summary>
+        public event EventHandler<TouchEventArgs> TouchBegan = null;
+
+        /// <summary>Event handler for the TouchMoved event</summary>
+        public event EventHandler<TouchEventArgs> TouchMoved = null;
+
+        /// <summary>Event handler for the TouchEnded event</summary>
+        public event EventHandler<TouchEventArgs> TouchEnded = null;
+
+        /// <summary>Event handler for the SensorChanged event</summary>
+        public event EventHandler<SensorEventArgs> SensorChanged = null;
+
+        #region Imports
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr sfWindowBase_create(VideoMode Mode, string Title, Styles Style);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr sfWindowBase_createUnicode(VideoMode Mode, IntPtr Title, Styles Style);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr sfWindowBase_createFromHandle(IntPtr Handle);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_destroy(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_close(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfWindowBase_isOpen(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfWindowBase_pollEvent(IntPtr CPointer, out Event Evt);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfWindowBase_waitEvent(IntPtr CPointer, out Event Evt);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern Vector2i sfWindowBase_getPosition(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setPosition(IntPtr CPointer, Vector2i position);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern Vector2u sfWindowBase_getSize(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setSize(IntPtr CPointer, Vector2u size);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setTitle(IntPtr CPointer, string title);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setUnicodeTitle(IntPtr CPointer, IntPtr title);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private unsafe static extern void sfWindowBase_setIcon(IntPtr CPointer, uint Width, uint Height, byte* Pixels);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setVisible(IntPtr CPointer, bool visible);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setMouseCursorVisible(IntPtr CPointer, bool Show);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setMouseCursorGrabbed(IntPtr CPointer, bool grabbed);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setMouseCursor(IntPtr CPointer, IntPtr cursor);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setKeyRepeatEnabled(IntPtr CPointer, bool Enable);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_setJoystickThreshold(IntPtr CPointer, float Threshold);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfWindowBase_requestFocus(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfWindowBase_hasFocus(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr sfWindowBase_getSystemHandle(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern bool sfWindowBase_createVulkanSurface(IntPtr CPointer, IntPtr vkInstance, out IntPtr surface, IntPtr vkAllocator);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern Vector2i sfMouse_getPosition(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfMouse_setPosition(Vector2i position, IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern Vector2i sfTouch_getPosition(uint Finger, IntPtr RelativeTo);
+        #endregion
+    }
+}

--- a/src/SFML.Window/WindowBase.cs
+++ b/src/SFML.Window/WindowBase.cs
@@ -67,7 +67,7 @@ namespace SFML.Window
             base(IntPtr.Zero)
         {
             // Copy the title to a null-terminated UTF-32 byte array
-            byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
+            var titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
 
             unsafe
             {
@@ -145,7 +145,7 @@ namespace SFML.Window
         public virtual void SetTitle(string title)
         {
             // Copy the title to a null-terminated UTF-32 byte array
-            byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
+            var titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
 
             unsafe
             {


### PR DESCRIPTION
This PR aims to implement most things from CSFML 2.6.0, along with some stuff that might be missing from CSFML 2.5.2.

Change list from 2.6.0:
- `sfFont_setSmooth` / `sfFont_isSmooth`
- `sfBlendMin` & `sfBlendMax`
- `sfFloatRect_getPosition`/`sfIntRect_getPosition` & `sfFloatRect_getSize`/`sfIntRect_getSize`
- Document MP3 support
- Add directional arrow resize cursors
- `sfFont_getBoldKerning`
- Add `sf::Vulkan` functions (partial)
- Add scancode support (partial)
- `sfRenderTexture_isSrgb` / `sfRenderWindow_isSrgb`
- `sfImage_saveToMemory` with `sfBuffer`
- `sf::WindowBase`

Other things which were done in this PR (probably missing from CSFML 2.5.2?):
- `drawVertexBufferRange` implementations from CSFML
- `TextureCoordinateType` implementation
- sRGB creation functions
- `sfContext_isExtensionAvailable` and `sfContext_getFunction`
- `sfWindowBase_createVulkanSurface`
- some other stuff I probably missed

Features which were not done due to issues:
- `sfVulkan_getGraphicsRequiredInstanceExtensions` - needs a CSFML release containing [CSFML#229](https://github.com/SFML/CSFML/pull/229)
- `sfKeyboard_getDescription` - this function returns an owning C pointer (`const char*`). I'm not sure how to handle the deallocation for it since there's no corresponding function to free the string

By the looks of it, this PR might overlap / conflict with #236, #239, #240, and maybe #238.

This PR is a mess and I don't expect it to pass first inspection, so any feedback is welcome.