### PR TITLE
Binding and API fixes

### DIFF
--- a/src/SFML.Audio/SoundRecorder.cs
+++ b/src/SFML.Audio/SoundRecorder.cs
@@ -20,9 +20,9 @@ namespace SFML.Audio
         public SoundRecorder() :
             base(IntPtr.Zero)
         {
-            myStartCallback = new StartCallback(OnStart);
+            myStartCallback = new StartCallback(StartRecording);
             myProcessCallback = new ProcessCallback(ProcessSamples);
-            myStopCallback = new StopCallback(OnStop);
+            myStopCallback = new StopCallback(StopRecording);
 
             CPointer = sfSoundRecorder_create(myStartCallback, myProcessCallback, myStopCallback, IntPtr.Zero);
         }
@@ -266,6 +266,19 @@ namespace SFML.Audio
         /// Function called directly by the C library ; convert
         /// arguments and forward them to the internal virtual function
         /// </summary>
+        /// <param name="userData">User data -- unused</param>
+        /// <returns>False to stop recording audio data, true to continue</returns>
+        ////////////////////////////////////////////////////////////
+        private bool StartRecording(IntPtr userData)
+        {
+            return OnStart();
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Function called directly by the C library ; convert
+        /// arguments and forward them to the internal virtual function
+        /// </summary>
         /// <param name="samples">Pointer to the array of samples</param>
         /// <param name="nbSamples">Number of samples in the array</param>
         /// <param name="userData">User data -- unused</param>
@@ -279,14 +292,26 @@ namespace SFML.Audio
             return OnProcessSamples(samplesArray);
         }
 
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Function called directly by the C library ; convert
+        /// arguments and forward them to the internal virtual function
+        /// </summary>
+        /// <param name="userData">User data -- unused</param>
+        ////////////////////////////////////////////////////////////
+        private void StopRecording(IntPtr userData)
+        {
+            OnStop();
+        }
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate bool StartCallback();
+        private delegate bool StartCallback(IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ProcessCallback(IntPtr samples, uint nbSamples, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void StopCallback();
+        private delegate void StopCallback(IntPtr userData);
 
         private readonly StartCallback myStartCallback;
         private readonly ProcessCallback myProcessCallback;

--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -557,12 +557,6 @@ namespace SFML.Graphics
         private static extern bool sfRenderTexture_setActive(IntPtr CPointer, bool Active);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern bool sfRenderTexture_saveGLStates(IntPtr CPointer);
-
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern bool sfRenderTexture_restoreGLStates(IntPtr CPointer);
-
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfRenderTexture_display(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -938,15 +938,6 @@ namespace SFML.Graphics
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern Vector2i sfTouch_getPositionRenderWindow(uint Finger, IntPtr RelativeTo);
-
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern bool sfRenderWindow_saveGLStates(IntPtr CPointer);
-
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern bool sfRenderWindow_restoreGLStates(IntPtr CPointer);
-
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern uint sfRenderWindow_getFrameTime(IntPtr CPointer);
         #endregion
     }
 }

--- a/src/SFML.Graphics/Shape.cs
+++ b/src/SFML.Graphics/Shape.cs
@@ -246,9 +246,6 @@ namespace SFML.Graphics
         private static extern IntPtr sfShape_create(GetPointCountCallbackType getPointCount, GetPointCallbackType getPoint, IntPtr userData);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfShape_copy(IntPtr Shape);
-
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfShape_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]

--- a/src/SFML.Graphics/Text.cs
+++ b/src/SFML.Graphics/Text.cs
@@ -451,9 +451,6 @@ namespace SFML.Graphics
         private static extern Styles sfText_getStyle(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern FloatRect sfText_getRect(IntPtr CPointer);
-
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern Vector2f sfText_findCharacterPos(IntPtr CPointer, uint Index);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]

--- a/src/SFML.Graphics/Texture.cs
+++ b/src/SFML.Graphics/Texture.cs
@@ -629,9 +629,6 @@ namespace SFML.Graphics
         private static extern uint sfTexture_getNativeHandle(IntPtr shader);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern FloatRect sfTexture_getTexCoords(IntPtr texture, IntRect rectangle);
-
-        [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern uint sfTexture_getMaximumSize();
         #endregion
     }

--- a/src/SFML.Window/Context.cs
+++ b/src/SFML.Window/Context.cs
@@ -40,9 +40,9 @@ namespace SFML.Window
         /// <param name="name">Name of the extension to check for</param>
         /// <returns>True if available, false if unavailable</returns>
         ////////////////////////////////////////////////////////////
-        public bool IsExtensionAvailable(string name)
+        public static bool IsExtensionAvailable(string name)
         {
-            return sfContext_isExtensionAvailable(myThis, name);
+            return sfContext_isExtensionAvailable(name);
         }
 
         ////////////////////////////////////////////////////////////
@@ -64,9 +64,9 @@ namespace SFML.Window
         /// <param name="name">Name of the function to get the address of</param>
         /// <returns>Address of the OpenGL function, <see cref="IntPtr.Zero"/> on failure</returns>
         ////////////////////////////////////////////////////////////
-        public IntPtr GetFunction(string name)
+        public static IntPtr GetFunction(string name)
         {
-            return sfContext_getFunction(myThis, name);
+            return sfContext_getFunction(name);
         }
 
         ////////////////////////////////////////////////////////////
@@ -120,13 +120,13 @@ namespace SFML.Window
         private static extern void sfContext_destroy(IntPtr View);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern bool sfContext_isExtensionAvailable(IntPtr View, string name);
+        private static extern bool sfContext_isExtensionAvailable(string name);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfContext_setActive(IntPtr View, bool Active);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfContext_getFunction(IntPtr View, string name);
+        private static extern IntPtr sfContext_getFunction(string name);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern ContextSettings sfContext_getSettings(IntPtr View);

--- a/src/SFML.Window/Joystick.cs
+++ b/src/SFML.Window/Joystick.cs
@@ -49,7 +49,7 @@ namespace SFML.Window
             /// <summary>The X axis of the point-of-view hat</summary>
             PovX,
 
-            /// <summary>TheY axis of the point-of-view hat</summary>
+            /// <summary>The Y axis of the point-of-view hat</summary>
             PovY
         };
 

--- a/src/SFML.Window/Mouse.cs
+++ b/src/SFML.Window/Mouse.cs
@@ -86,7 +86,7 @@ namespace SFML.Window
         /// <param name="relativeTo">Reference window</param>
         /// <returns>Current position of the mouse</returns>
         ////////////////////////////////////////////////////////////
-        public static Vector2i GetPosition(Window relativeTo)
+        public static Vector2i GetPosition(WindowBase relativeTo)
         {
             if (relativeTo != null)
             {
@@ -120,7 +120,7 @@ namespace SFML.Window
         /// <param name="position">New position of the mouse</param>
         /// <param name="relativeTo">Reference window</param>
         ////////////////////////////////////////////////////////////
-        public static void SetPosition(Vector2i position, Window relativeTo)
+        public static void SetPosition(Vector2i position, WindowBase relativeTo)
         {
             if (relativeTo != null)
             {

--- a/src/SFML.Window/Touch.cs
+++ b/src/SFML.Window/Touch.cs
@@ -45,7 +45,7 @@ namespace SFML.Window
         /// <param name="RelativeTo">Reference window</param>
         /// <returns>Current position of the finger</returns>
         ////////////////////////////////////////////////////////////
-        public static Vector2i GetPosition(uint Finger, Window RelativeTo)
+        public static Vector2i GetPosition(uint Finger, WindowBase RelativeTo)
         {
             if (RelativeTo != null)
             {

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -376,6 +376,46 @@ namespace SFML.Window
 
         ////////////////////////////////////////////////////////////
         /// <summary>
+        /// Internal function to get the mouse position relative to the window.
+        /// This function is protected because it is called by another class of
+        /// another module, it is not meant to be called by users.
+        /// </summary>
+        /// <returns>Relative mouse position</returns>
+        ////////////////////////////////////////////////////////////
+        protected internal override Vector2i InternalGetMousePosition()
+        {
+            return sfMouse_getPosition(CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Internal function to set the mouse position relative to the window.
+        /// This function is protected because it is called by another class of
+        /// another module, it is not meant to be called by users.
+        /// </summary>
+        /// <param name="position">Relative mouse position</param>
+        ////////////////////////////////////////////////////////////
+        protected internal override void InternalSetMousePosition(Vector2i position)
+        {
+            sfMouse_setPosition(position, CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Internal function to get the touch position relative to the window.
+        /// This function is protected because it is called by another class of
+        /// another module, it is not meant to be called by users.
+        /// </summary>
+        /// <param name="Finger">Finger index</param>
+        /// <returns>Relative touch position</returns>
+        ////////////////////////////////////////////////////////////
+        protected internal override Vector2i InternalGetTouchPosition(uint Finger)
+        {
+            return sfTouch_getPosition(Finger, CPointer);
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
         /// Internal function to get the next event (non-blocking)
         /// </summary>
         /// <param name="eventToFill">Variable to fill with the raw pointer to the event structure</param>
@@ -486,9 +526,6 @@ namespace SFML.Window
         private static extern void sfWindow_setFramerateLimit(IntPtr CPointer, uint Limit);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern uint sfWindow_getFrameTime(IntPtr CPointer);
-
-        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfWindow_setJoystickThreshold(IntPtr CPointer, float Threshold);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
@@ -499,6 +536,15 @@ namespace SFML.Window
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfWindow_hasFocus(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern Vector2i sfMouse_getPosition(IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern void sfMouse_setPosition(Vector2i position, IntPtr CPointer);
+
+        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
+        private static extern Vector2i sfTouch_getPosition(uint Finger, IntPtr RelativeTo);
         #endregion
     }
 }

--- a/src/SFML.Window/WindowBase.cs
+++ b/src/SFML.Window/WindowBase.cs
@@ -394,7 +394,7 @@ namespace SFML.Window
         ////////////////////////////////////////////////////////////
         protected internal virtual Vector2i InternalGetMousePosition()
         {
-            return sfMouse_getPosition(CPointer);
+            throw new NotImplementedException("Currently not available");
         }
 
         ////////////////////////////////////////////////////////////
@@ -407,7 +407,7 @@ namespace SFML.Window
         ////////////////////////////////////////////////////////////
         protected internal virtual void InternalSetMousePosition(Vector2i position)
         {
-            sfMouse_setPosition(position, CPointer);
+            throw new NotImplementedException("Currently not available");
         }
 
         ////////////////////////////////////////////////////////////
@@ -421,7 +421,7 @@ namespace SFML.Window
         ////////////////////////////////////////////////////////////
         protected internal virtual Vector2i InternalGetTouchPosition(uint Finger)
         {
-            return sfTouch_getPosition(Finger, CPointer);
+            throw new NotImplementedException("Currently not available");
         }
 
         ////////////////////////////////////////////////////////////
@@ -783,15 +783,6 @@ namespace SFML.Window
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfWindowBase_createVulkanSurface(IntPtr CPointer, IntPtr vkInstance, out IntPtr surface, IntPtr vkAllocator);
-
-        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern Vector2i sfMouse_getPosition(IntPtr CPointer);
-
-        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern void sfMouse_setPosition(Vector2i position, IntPtr CPointer);
-
-        [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern Vector2i sfTouch_getPosition(uint Finger, IntPtr RelativeTo);
         #endregion
     }
 }


### PR DESCRIPTION
Fixed binding signatures (which were originally broken by yours truly):
```
CSFML_WINDOW_API sfBool sfContext_isExtensionAvailable(const char* name);
CSFML_WINDOW_API GlFunctionPointer sfContext_getFunction(const char* name);
```

Removed old bindings that don't exist anymore in CSFML:
```
private static extern bool sfRenderTexture_saveGLStates(IntPtr CPointer);
private static extern bool sfRenderTexture_restoreGLStates(IntPtr CPointer);
private static extern bool sfRenderWindow_saveGLStates(IntPtr CPointer);
private static extern bool sfRenderWindow_restoreGLStates(IntPtr CPointer);
private static extern uint sfRenderWindow_getFrameTime(IntPtr CPointer);
private static extern uint sfWindow_getFrameTime(IntPtr CPointer);
private static extern IntPtr sfShape_copy(IntPtr Shape);
private static extern FloatRect sfText_getRect(IntPtr CPointer);
private static extern FloatRect sfTexture_getTexCoords(IntPtr texture, IntRect rectangle);
```

Fixed missing userdata pointers in SoundRecorder callbacks.

Moved `sfMouse_getPosition`, `sfMouse_setPosition`, and `sfTouch_getPosition` back to `Window`, since those functions operate on `sfWindow` structs and not `sfWindowBase`. `WindowBase` will need its own CSFML functions that are not available at the moment, which is why I used `NotImplementedException` for the time being.

Also changed `Mouse` and `Touch` functions to use `WindowBase` instead of `Window`.