### PR TITLE
Use UIntPtr for size_t arguments and return values from CSFML

### DIFF
--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -77,7 +77,7 @@ namespace SFML.Audio
             GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
             try
             {
-                CPointer = sfMusic_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
+                CPointer = sfMusic_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
             }
             finally
             {
@@ -408,7 +408,7 @@ namespace SFML.Audio
         private unsafe static extern IntPtr sfMusic_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfMusic_createFromMemory(IntPtr data, ulong size);
+        private static extern IntPtr sfMusic_createFromMemory(IntPtr data, UIntPtr size);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfMusic_destroy(IntPtr MusicStream);

--- a/src/SFML.Audio/SoundBuffer.cs
+++ b/src/SFML.Audio/SoundBuffer.cs
@@ -75,7 +75,7 @@ namespace SFML.Audio
             GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
             try
             {
-                CPointer = sfSoundBuffer_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
+                CPointer = sfSoundBuffer_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
             }
             finally
             {
@@ -224,7 +224,7 @@ namespace SFML.Audio
         private unsafe static extern IntPtr sfSoundBuffer_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern IntPtr sfSoundBuffer_createFromMemory(IntPtr data, ulong size);
+        private unsafe static extern IntPtr sfSoundBuffer_createFromMemory(IntPtr data, UIntPtr size);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private unsafe static extern IntPtr sfSoundBuffer_createFromSamples(short* Samples, ulong SampleCount, uint ChannelsCount, uint SampleRate);

--- a/src/SFML.Audio/SoundRecorder.cs
+++ b/src/SFML.Audio/SoundRecorder.cs
@@ -204,10 +204,10 @@ namespace SFML.Audio
             {
                 unsafe
                 {
-                    uint Count;
+                    UIntPtr Count;
                     IntPtr* DevicesPtr = sfSoundRecorder_getAvailableDevices(out Count);
-                    string[] Devices = new string[Count];
-                    for (uint i = 0; i < Count; ++i)
+                    string[] Devices = new string[(int)Count];
+                    for (int i = 0; i < (int)Count; ++i)
                     {
                         Devices[i] = Marshal.PtrToStringAnsi(DevicesPtr[i]);
                     }
@@ -284,9 +284,9 @@ namespace SFML.Audio
         /// <param name="userData">User data -- unused</param>
         /// <returns>False to stop recording audio data, true to continue</returns>
         ////////////////////////////////////////////////////////////
-        private bool ProcessSamples(IntPtr samples, uint nbSamples, IntPtr userData)
+        private bool ProcessSamples(IntPtr samples, UIntPtr nbSamples, IntPtr userData)
         {
-            short[] samplesArray = new short[nbSamples];
+            short[] samplesArray = new short[(int)nbSamples];
             Marshal.Copy(samples, samplesArray, 0, samplesArray.Length);
 
             return OnProcessSamples(samplesArray);
@@ -308,7 +308,7 @@ namespace SFML.Audio
         private delegate bool StartCallback(IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate bool ProcessCallback(IntPtr samples, uint nbSamples, IntPtr userData);
+        private delegate bool ProcessCallback(IntPtr samples, UIntPtr nbSamples, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void StopCallback(IntPtr userData);
@@ -340,7 +340,7 @@ namespace SFML.Audio
         private static extern void sfSoundRecorder_setProcessingInterval(IntPtr SoundRecorder, Time Interval);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern IntPtr* sfSoundRecorder_getAvailableDevices(out uint Count);
+        private unsafe static extern IntPtr* sfSoundRecorder_getAvailableDevices(out UIntPtr Count);
 
         [DllImport(CSFML.audio, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfSoundRecorder_getDefaultDevice();

--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -90,7 +90,7 @@ namespace SFML.Graphics
             GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
             try
             {
-                CPointer = sfImage_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
+                CPointer = sfImage_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
             }
             finally
             {
@@ -389,7 +389,7 @@ namespace SFML.Graphics
         private unsafe static extern IntPtr sfImage_createFromStream(IntPtr stream);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern IntPtr sfImage_createFromMemory(IntPtr data, ulong size);
+        private unsafe static extern IntPtr sfImage_createFromMemory(IntPtr data, UIntPtr size);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfImage_copy(IntPtr Image);

--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -410,7 +410,7 @@ namespace SFML.Graphics
             {
                 fixed (Vertex* vertexPtr = vertices)
                 {
-                    sfRenderTexture_drawPrimitives(CPointer, vertexPtr + start, count, type, ref marshaledStates);
+                    sfRenderTexture_drawPrimitives(CPointer, vertexPtr + start, (UIntPtr)count, type, ref marshaledStates);
                 }
             }
         }
@@ -599,7 +599,7 @@ namespace SFML.Graphics
         private static extern bool sfRenderTexture_generateMipmap(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern void sfRenderTexture_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, uint vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
+        private unsafe static extern void sfRenderTexture_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, UIntPtr vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfRenderTexture_pushGLStates(IntPtr CPointer);

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -602,7 +602,7 @@ namespace SFML.Graphics
             {
                 fixed (Vertex* vertexPtr = vertices)
                 {
-                    sfRenderWindow_drawPrimitives(CPointer, vertexPtr + start, count, type, ref marshaledStates);
+                    sfRenderWindow_drawPrimitives(CPointer, vertexPtr + start, (UIntPtr)count, type, ref marshaledStates);
                 }
             }
         }
@@ -930,7 +930,7 @@ namespace SFML.Graphics
         private static extern Vector2i sfRenderWindow_mapCoordsToPixel(IntPtr CPointer, Vector2f point, IntPtr View);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern void sfRenderWindow_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, uint vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
+        private unsafe static extern void sfRenderWindow_drawPrimitives(IntPtr CPointer, Vertex* vertexPtr, UIntPtr vertexCount, PrimitiveType type, ref RenderStates.MarshalData renderStates);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfRenderWindow_pushGLStates(IntPtr CPointer);

--- a/src/SFML.Graphics/Shader.cs
+++ b/src/SFML.Graphics/Shader.cs
@@ -406,7 +406,7 @@ namespace SFML.Graphics
         {
             fixed (float* data = array)
             {
-                sfShader_setFloatUniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setFloatUniformArray(CPointer, name, data, (UIntPtr)array.Length);
             }
         }
 
@@ -421,7 +421,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Vec2* data = array)
             {
-                sfShader_setVec2UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setVec2UniformArray(CPointer, name, data, (UIntPtr)array.Length);
             }
         }
 
@@ -436,7 +436,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Vec3* data = array)
             {
-                sfShader_setVec3UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setVec3UniformArray(CPointer, name, data, (UIntPtr)array.Length);
             }
         }
 
@@ -451,7 +451,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Vec4* data = array)
             {
-                sfShader_setVec4UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setVec4UniformArray(CPointer, name, data, (UIntPtr)array.Length);
             }
         }
 
@@ -466,7 +466,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Mat3* data = array)
             {
-                sfShader_setMat3UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setMat3UniformArray(CPointer, name, data, (UIntPtr)array.Length);
             }
         }
 
@@ -481,7 +481,7 @@ namespace SFML.Graphics
         {
             fixed (Glsl.Mat4* data = array)
             {
-                sfShader_setMat4UniformArray(CPointer, name, data, (uint)array.Length);
+                sfShader_setMat4UniformArray(CPointer, name, data, (UIntPtr)array.Length);
             }
         }
 
@@ -816,22 +816,22 @@ namespace SFML.Graphics
         private static extern void sfShader_setCurrentTextureUniform(IntPtr shader, string name);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setFloatUniformArray(IntPtr shader, string name, float* data, uint length);
+        private static extern unsafe void sfShader_setFloatUniformArray(IntPtr shader, string name, float* data, UIntPtr length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setVec2UniformArray(IntPtr shader, string name, Glsl.Vec2* data, uint length);
+        private static extern unsafe void sfShader_setVec2UniformArray(IntPtr shader, string name, Glsl.Vec2* data, UIntPtr length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setVec3UniformArray(IntPtr shader, string name, Glsl.Vec3* data, uint length);
+        private static extern unsafe void sfShader_setVec3UniformArray(IntPtr shader, string name, Glsl.Vec3* data, UIntPtr length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setVec4UniformArray(IntPtr shader, string name, Glsl.Vec4* data, uint length);
+        private static extern unsafe void sfShader_setVec4UniformArray(IntPtr shader, string name, Glsl.Vec4* data, UIntPtr length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setMat3UniformArray(IntPtr shader, string name, Glsl.Mat3* data, uint length);
+        private static extern unsafe void sfShader_setMat3UniformArray(IntPtr shader, string name, Glsl.Mat3* data, UIntPtr length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe void sfShader_setMat4UniformArray(IntPtr shader, string name, Glsl.Mat4* data, uint length);
+        private static extern unsafe void sfShader_setMat4UniformArray(IntPtr shader, string name, Glsl.Mat4* data, UIntPtr length);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity, Obsolete]
         private static extern void sfShader_setFloatParameter(IntPtr shader, string name, float x);

--- a/src/SFML.Graphics/Shape.cs
+++ b/src/SFML.Graphics/Shape.cs
@@ -215,9 +215,9 @@ namespace SFML.Graphics
         /// Callback passed to the C API
         /// </summary>
         ////////////////////////////////////////////////////////////
-        private uint InternalGetPointCount(IntPtr userData)
+        private UIntPtr InternalGetPointCount(IntPtr userData)
         {
-            return GetPointCount();
+            return (UIntPtr)GetPointCount();
         }
 
         ////////////////////////////////////////////////////////////
@@ -225,16 +225,16 @@ namespace SFML.Graphics
         /// Callback passed to the C API
         /// </summary>
         ////////////////////////////////////////////////////////////
-        private Vector2f InternalGetPoint(uint index, IntPtr userData)
+        private Vector2f InternalGetPoint(UIntPtr index, IntPtr userData)
         {
-            return GetPoint(index);
+            return GetPoint((uint)index);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate uint GetPointCountCallbackType(IntPtr UserData);
+        private delegate UIntPtr GetPointCountCallbackType(IntPtr UserData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate Vector2f GetPointCallbackType(uint index, IntPtr UserData);
+        private delegate Vector2f GetPointCallbackType(UIntPtr index, IntPtr UserData);
 
         private readonly GetPointCountCallbackType myGetPointCountCallback;
         private readonly GetPointCallbackType myGetPointCallback;

--- a/src/SFML.Graphics/Text.cs
+++ b/src/SFML.Graphics/Text.cs
@@ -282,7 +282,7 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public Vector2f FindCharacterPos(uint index)
         {
-            return sfText_findCharacterPos(CPointer, index);
+            return sfText_findCharacterPos(CPointer, (UIntPtr)index);
         }
 
         ////////////////////////////////////////////////////////////
@@ -451,7 +451,7 @@ namespace SFML.Graphics
         private static extern Styles sfText_getStyle(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern Vector2f sfText_findCharacterPos(IntPtr CPointer, uint Index);
+        private static extern Vector2f sfText_findCharacterPos(IntPtr CPointer, UIntPtr Index);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern FloatRect sfText_getLocalBounds(IntPtr CPointer);

--- a/src/SFML.Graphics/Texture.cs
+++ b/src/SFML.Graphics/Texture.cs
@@ -211,12 +211,12 @@ namespace SFML.Graphics
             {
                 if (srgb)
                 {
-                    CPointer = sfTexture_createSrgbFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length), ref area);
+                    CPointer = sfTexture_createSrgbFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length, ref area);
                 }
                 else
                 {
-                    CPointer = sfTexture_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length), ref area);
-                }
+                    CPointer = sfTexture_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length, ref area);
+                } 
             }
             finally
             {
@@ -582,10 +582,10 @@ namespace SFML.Graphics
         private static extern IntPtr sfTexture_createSrgbFromImage(IntPtr image, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfTexture_createFromMemory(IntPtr data, ulong size, ref IntRect area);
+        private static extern IntPtr sfTexture_createFromMemory(IntPtr data, UIntPtr size, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern IntPtr sfTexture_createSrgbFromMemory(IntPtr data, ulong size, ref IntRect area);
+        private static extern IntPtr sfTexture_createSrgbFromMemory(IntPtr data, UIntPtr size, ref IntRect area);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfTexture_copy(IntPtr texture);

--- a/src/SFML.Graphics/VertexArray.cs
+++ b/src/SFML.Graphics/VertexArray.cs
@@ -66,7 +66,7 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public uint VertexCount
         {
-            get { return sfVertexArray_getVertexCount(CPointer); }
+            get { return (uint)sfVertexArray_getVertexCount(CPointer); }
         }
 
         ////////////////////////////////////////////////////////////
@@ -87,14 +87,14 @@ namespace SFML.Graphics
             {
                 unsafe
                 {
-                    return *sfVertexArray_getVertex(CPointer, index);
+                    return *sfVertexArray_getVertex(CPointer, (UIntPtr)index);
                 }
             }
             set
             {
                 unsafe
                 {
-                    *sfVertexArray_getVertex(CPointer, index) = value;
+                    *sfVertexArray_getVertex(CPointer, (UIntPtr)index) = value;
                 }
             }
         }
@@ -124,7 +124,7 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public void Resize(uint vertexCount)
         {
-            sfVertexArray_resize(CPointer, vertexCount);
+            sfVertexArray_resize(CPointer, (UIntPtr)vertexCount);
         }
 
         ////////////////////////////////////////////////////////////
@@ -208,16 +208,16 @@ namespace SFML.Graphics
         private static extern void sfVertexArray_destroy(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern uint sfVertexArray_getVertexCount(IntPtr CPointer);
+        private static extern UIntPtr sfVertexArray_getVertexCount(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern unsafe Vertex* sfVertexArray_getVertex(IntPtr CPointer, uint index);
+        private static extern unsafe Vertex* sfVertexArray_getVertex(IntPtr CPointer, UIntPtr index);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfVertexArray_clear(IntPtr CPointer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern void sfVertexArray_resize(IntPtr CPointer, uint vertexCount);
+        private static extern void sfVertexArray_resize(IntPtr CPointer, UIntPtr vertexCount);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfVertexArray_append(IntPtr CPointer, Vertex vertex);

--- a/src/SFML.Graphics/VertexBuffer.cs
+++ b/src/SFML.Graphics/VertexBuffer.cs
@@ -330,11 +330,11 @@ namespace SFML.Graphics
 
             if (target is RenderWindow)
             {
-                sfRenderWindow_drawVertexBufferRange(( (RenderWindow)target ).CPointer, CPointer, firstVertex, vertexCount, ref marshaledStates);
+                sfRenderWindow_drawVertexBufferRange(( (RenderWindow)target ).CPointer, CPointer, (UIntPtr)firstVertex, (UIntPtr)vertexCount, ref marshaledStates);
             }
             else if (target is RenderTexture)
             {
-                sfRenderTexture_drawVertexBufferRange(( (RenderTexture)target ).CPointer, CPointer, firstVertex, vertexCount, ref marshaledStates);
+                sfRenderTexture_drawVertexBufferRange(( (RenderTexture)target ).CPointer, CPointer, (UIntPtr)firstVertex, (UIntPtr)vertexCount, ref marshaledStates);
             }
         }
 
@@ -385,13 +385,13 @@ namespace SFML.Graphics
         private static extern void sfRenderWindow_drawVertexBuffer(IntPtr CPointer, IntPtr VertexArray, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern void sfRenderWindow_drawVertexBufferRange(IntPtr CPointer, IntPtr VertexBuffer, uint firstVertex, uint vertexCount, ref RenderStates.MarshalData states);
+        private static extern void sfRenderWindow_drawVertexBufferRange(IntPtr CPointer, IntPtr VertexBuffer, UIntPtr firstVertex, UIntPtr vertexCount, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern void sfRenderTexture_drawVertexBuffer(IntPtr CPointer, IntPtr VertexBuffer, ref RenderStates.MarshalData states);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern void sfRenderTexture_drawVertexBufferRange(IntPtr CPointer, IntPtr VertexBuffer, uint firstVertex, uint vertexCount, ref RenderStates.MarshalData states);
+        private static extern void sfRenderTexture_drawVertexBufferRange(IntPtr CPointer, IntPtr VertexBuffer, UIntPtr firstVertex, UIntPtr vertexCount, ref RenderStates.MarshalData states);
         #endregion
     }
 }

--- a/src/SFML.System/Buffer.cs
+++ b/src/SFML.System/Buffer.cs
@@ -42,7 +42,7 @@ namespace SFML.System
                 return Array.Empty<byte>();
             }
 
-            var data = new byte[size];
+            var data = new byte[(int)size];
             Marshal.Copy(ptr, data, 0, (int)size);
 
             return data;
@@ -78,7 +78,7 @@ namespace SFML.System
         private static extern void sfBuffer_destroy(IntPtr buffer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private static extern uint sfBuffer_getSize(IntPtr buffer);
+        private static extern UIntPtr sfBuffer_getSize(IntPtr buffer);
 
         [DllImport(CSFML.graphics, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfBuffer_getData(IntPtr buffer);

--- a/src/SFML.Window/VideoMode.cs
+++ b/src/SFML.Window/VideoMode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using SFML.System;
@@ -63,10 +64,10 @@ namespace SFML.Window
             {
                 unsafe
                 {
-                    uint Count;
+                    UIntPtr Count;
                     VideoMode* ModesPtr = sfVideoMode_getFullscreenModes(out Count);
-                    VideoMode[] Modes = new VideoMode[Count];
-                    for (uint i = 0; i < Count; ++i)
+                    VideoMode[] Modes = new VideoMode[(int)Count];
+                    for (int i = 0; i < (int)Count; ++i)
                     {
                         Modes[i] = ModesPtr[i];
                     }
@@ -114,7 +115,7 @@ namespace SFML.Window
         private static extern VideoMode sfVideoMode_getDesktopMode();
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern VideoMode* sfVideoMode_getFullscreenModes(out uint Count);
+        private unsafe static extern VideoMode* sfVideoMode_getFullscreenModes(out UIntPtr Count);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern bool sfVideoMode_isValid(VideoMode Mode);

--- a/src/SFML.Window/Vulkan.cs
+++ b/src/SFML.Window/Vulkan.cs
@@ -45,9 +45,9 @@ namespace SFML.Window
             unsafe
             {
                 var extensionsPtr = sfVulkan_getGraphicsRequiredInstanceExtensions(out var count);
-                var extensions = new string[count];
+                var extensions = new string[(int)count];
 
-                for (uint i = 0; i < count; ++i)
+                for (int i = 0; i < (int)count; ++i)
                 {
                     extensions[i] = Marshal.PtrToStringAnsi(extensionsPtr[i]);
                 }
@@ -64,7 +64,7 @@ namespace SFML.Window
         private static extern IntPtr sfVulkan_getFunction(string name);
 
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
-        private unsafe static extern IntPtr* sfVulkan_getGraphicsRequiredInstanceExtensions(out uint count);
+        private unsafe static extern IntPtr* sfVulkan_getGraphicsRequiredInstanceExtensions(out UIntPtr count);
         #endregion
     }
 }


### PR DESCRIPTION
Supersedes #238.

Most of the code is the same as DemoXin's, but I used `UIntPtr` directly and updated it with the remaining places that use `size_t` in CSFML.