### PR TITLE
Fix AccessViolationException on KeyPress

### DIFF
--- a/src/SFML.Window/Event.cs
+++ b/src/SFML.Window/Event.cs
@@ -92,6 +92,9 @@ namespace SFML.Window
         /// <summary>Code of the key. See <see cref="Keyboard.Key"/></summary>
         public Keyboard.Key Code;
 
+        /// <summary>Physical code of the key. See <see cref="Keyboard.Scancode"/></summary>
+        public Keyboard.Scancode Scancode;
+
         /// <summary>Is the Alt modifier pressed?</summary>
         public int Alt;
 
@@ -294,7 +297,7 @@ namespace SFML.Window
     /// Event defines a system event and its parameters
     /// </summary>
     ////////////////////////////////////////////////////////////
-    [StructLayout(LayoutKind.Explicit, Size = 20)]
+    [StructLayout(LayoutKind.Explicit, Size = 28)]
     public struct Event
     {
         /// <summary>Type of event (see EventType enum)</summary>

--- a/src/SFML.Window/EventArgs.cs
+++ b/src/SFML.Window/EventArgs.cs
@@ -18,6 +18,7 @@ namespace SFML.Window
         public KeyEventArgs(KeyEvent e)
         {
             Code = e.Code;
+            Scancode = e.Scancode;
             Alt = e.Alt != 0;
             Control = e.Control != 0;
             Shift = e.Shift != 0;
@@ -34,14 +35,18 @@ namespace SFML.Window
         {
             return "[KeyEventArgs]" +
                    " Code(" + Code + ")" +
+                   " Scancode(" + Scancode + ")" +
                    " Alt(" + Alt + ")" +
                    " Control(" + Control + ")" +
                    " Shift(" + Shift + ")" +
                    " System(" + System + ")";
         }
 
-        /// <summary>Code of the key (see KeyCode enum)</summary>
+        /// <summary>Code of the key (see <see cref="Keyboard.Key"/>)</summary>
         public Keyboard.Key Code;
+
+        /// <summary>Physical code of the key (see <see cref="Keyboard.Scancode"/>)</summary>
+        public Keyboard.Scancode Scancode;
 
         /// <summary>Is the Alt modifier pressed?</summary>
         public bool Alt;


### PR DESCRIPTION
The scancode field had been added to the key event in CSFML and this change was brought downstream in c68ed27. Master has been broken ever since because there was never any followup to update the binding.
It's a very simple bug and it's a severe one, and the exact cause has been known about for weeks, so why the fuck is this taking so long to address? Anyway, hope this helps.

Closes #245