### PR TITLE
Separation of Event Management from Window Base to a custom type

### DIFF
--- a/examples/Examples.sln
+++ b/examples/Examples.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFML.Window", "..\src\SFML.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "netcore", "netcore\netcore.csproj", "{93B8425A-AC40-4486-96AF-20027B738C09}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "custom_eventman", "custom_eventman\custom_eventman.csproj", "{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +185,18 @@ Global
 		{93B8425A-AC40-4486-96AF-20027B738C09}.Release|x64.Build.0 = Release|Any CPU
 		{93B8425A-AC40-4486-96AF-20027B738C09}.Release|x86.ActiveCfg = Release|Any CPU
 		{93B8425A-AC40-4486-96AF-20027B738C09}.Release|x86.Build.0 = Release|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Debug|x64.Build.0 = Debug|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Debug|x86.Build.0 = Debug|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Release|x64.ActiveCfg = Release|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Release|x64.Build.0 = Release|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Release|x86.ActiveCfg = Release|Any CPU
+		{03A24BD1-B960-4E4A-AF8A-22BA8DA9BAFC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/custom_eventman/Program.cs
+++ b/examples/custom_eventman/Program.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using SFML.Graphics;
+using SFML.Window;
+namespace Program;
+
+public struct SimpleEventPasser : IEventMan
+{
+    private readonly List<Event> _events;
+    public SimpleEventPasser() => _events = new();
+    public void HandleEvent(Event eve)
+    {
+        switch (eve.Type)
+        {
+            case EventType.Closed:
+            case EventType.LostFocus:
+            case EventType.GainedFocus:
+            case EventType.KeyPressed:
+            case EventType.KeyReleased:
+                _events.Add(eve);
+                break;
+            default: // Filtering out all other events
+                break;
+        }
+    }
+    public void PrepareFrame() => _events.Clear();
+    public IEnumerable<Event> ProcessEvents() => _events;
+}
+public static class Program
+{
+    public static void Main()
+    {
+        var event_man = new SimpleEventPasser();
+        var window = new RenderWindow(
+            new(640, 480),
+            "Custom Event Manager example",
+            Styles.Default,
+            event_man
+        );
+        while (window.IsOpen)
+        {
+            window.Clear(Color.Black);
+            window.DispatchEvents();
+            window.Display();
+            foreach (var e in event_man.ProcessEvents())
+            {
+                System.Console.WriteLine(e.ToString());
+                if (e.Type == EventType.Closed)
+                {
+                    window.Close();
+                }
+            }
+        }
+    }
+}

--- a/examples/custom_eventman/custom_eventman.csproj
+++ b/examples/custom_eventman/custom_eventman.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SFML.Net\SFML.Net.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/netcore/Program.cs
+++ b/examples/netcore/Program.cs
@@ -18,7 +18,7 @@ namespace netcore
             var sound = new Sound(GenerateSineWave(frequency: 440.0, volume: .25, seconds: 1));
 
             var window = new RenderWindow(new VideoMode(800, 600), "SFML running in .NET Core");
-            window.Closed += (_, __) => window.Close();
+            (window.SfmlEventManager as SubscribeManager).Closed += (_, __) => window.Close();
 
             sound.Play();
 

--- a/examples/opengl/OpenGL.cs
+++ b/examples/opengl/OpenGL.cs
@@ -31,9 +31,10 @@ namespace opengl
             //GraphicsContext context = new GraphicsContext(new ContextHandle(IntPtr.Zero), null);
 
             // Setup event handlers
-            window.Closed += new EventHandler(OnClosed);
-            window.KeyPressed += new EventHandler<KeyEventArgs>(OnKeyPressed);
-            window.Resized += new EventHandler<SizeEventArgs>(OnResized);
+            var handler = window.SfmlEventManager as SubscribeManager;
+            handler.Closed += new EventHandler(OnClosed);
+            handler.KeyPressed += new EventHandler<KeyEventArgs>(OnKeyPressed);
+            handler.Resized += new EventHandler<SizeEventArgs>(OnResized);
 
             // Create a sprite for the background
             var background = new Sprite(new Texture("resources/background.jpg"));

--- a/examples/shader/Shader.cs
+++ b/examples/shader/Shader.cs
@@ -280,8 +280,9 @@ namespace shader
             window.SetVerticalSyncEnabled(true);
 
             // Setup event handlers
-            window.Closed += OnClosed;
-            window.KeyPressed += OnKeyPressed;
+            var handler = window.SfmlEventManager as SubscribeManager;
+            handler.Closed += OnClosed;
+            handler.KeyPressed += OnKeyPressed;
 
             // Load the application font and pass it to the Effect class
             var font = new Font("resources/sansation.ttf");

--- a/examples/visualbasic/OpenGL.vb
+++ b/examples/visualbasic/OpenGL.vb
@@ -177,7 +177,7 @@ Module OpenGL
     ''' <summary>
     ''' Function called when the window is closed
     ''' </summary>
-    Sub App_Closed(ByVal sender As Object, ByVal e As EventArgs) Handles window.Closed
+    Sub App_Closed(ByVal sender As Object, ByVal e As EventArgs) Handles window.SfmlEventManager.Closed
         Dim window = CType(sender, RenderWindow)
         window.Close()
     End Sub
@@ -185,7 +185,7 @@ Module OpenGL
     ''' <summary>
     ''' Function called when a key is pressed
     ''' </summary>
-    Sub App_KeyPressed(ByVal sender As Object, ByVal e As KeyEventArgs) Handles window.KeyPressed
+    Sub App_KeyPressed(ByVal sender As Object, ByVal e As KeyEventArgs) Handles window.SfmlEventManager.KeyPressed
         Dim window = CType(sender, RenderWindow)
         If e.Code = Keyboard.Key.Escape Then
             window.Close()
@@ -195,7 +195,7 @@ Module OpenGL
     ''' <summary>
     ''' Function called when the window is resized
     ''' </summary>
-    Sub App_Resized(ByVal sender As Object, ByVal e As SizeEventArgs) Handles window.Resized
+    Sub App_Resized(ByVal sender As Object, ByVal e As SizeEventArgs) Handles window.SfmlEventManager.Resized
         GL.Viewport(0, 0, e.Width, e.Height)
     End Sub
 

--- a/examples/window/Program.cs
+++ b/examples/window/Program.cs
@@ -20,7 +20,7 @@ namespace window_core
         {
             var mode = new SFML.Window.VideoMode(800, 600);
             var window = new SFML.Graphics.RenderWindow(mode, "SFML works!");
-            window.KeyPressed += Window_KeyPressed;
+            (window.SfmlEventManager as SFML.Window.SubscribeManager).KeyPressed += Window_KeyPressed;
 
             var circle = new SFML.Graphics.CircleShape(100f)
             {

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -21,9 +21,10 @@ namespace SFML.Graphics
         /// </summary>
         /// <param name="mode">Video mode to use</param>
         /// <param name="title">Title of the window</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public RenderWindow(VideoMode mode, string title) :
-            this(mode, title, Styles.Default, new ContextSettings(0, 0))
+        public RenderWindow(VideoMode mode, string title, IEventMan manager = null) :
+            this(mode, title, Styles.Default, new ContextSettings(0, 0), manager)
         {
         }
 
@@ -34,9 +35,10 @@ namespace SFML.Graphics
         /// <param name="mode">Video mode to use</param>
         /// <param name="title">Title of the window</param>
         /// <param name="style">Window style (Resize | Close by default)</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public RenderWindow(VideoMode mode, string title, Styles style) :
-            this(mode, title, style, new ContextSettings(0, 0))
+        public RenderWindow(VideoMode mode, string title, Styles style, IEventMan manager = null) :
+            this(mode, title, style, new ContextSettings(0, 0), manager)
         {
         }
 
@@ -48,9 +50,10 @@ namespace SFML.Graphics
         /// <param name="title">Title of the window</param>
         /// <param name="style">Window style (Resize | Close by default)</param>
         /// <param name="settings">Creation parameters</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public RenderWindow(VideoMode mode, string title, Styles style, ContextSettings settings) :
-            base(IntPtr.Zero, 0)
+        public RenderWindow(VideoMode mode, string title, Styles style, ContextSettings settings, IEventMan manager = null) :
+            base(manager, IntPtr.Zero)
         {
             // Copy the string to a null-terminated UTF-32 byte array
             byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
@@ -70,9 +73,10 @@ namespace SFML.Graphics
         /// Create the window from an existing control with default creation settings
         /// </summary>
         /// <param name="handle">Platform-specific handle of the control</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public RenderWindow(IntPtr handle) :
-            this(handle, new ContextSettings(0, 0))
+        public RenderWindow(IntPtr handle, IEventMan manager = null) :
+            this(handle, new ContextSettings(0, 0), manager)
         {
         }
 
@@ -82,9 +86,10 @@ namespace SFML.Graphics
         /// </summary>
         /// <param name="handle">Platform-specific handle of the control</param>
         /// <param name="settings">Creation parameters</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public RenderWindow(IntPtr handle, ContextSettings settings) :
-            base(sfRenderWindow_createFromHandle(handle, ref settings), 0)
+        public RenderWindow(IntPtr handle, ContextSettings settings, IEventMan manager = null) :
+            base(manager, sfRenderWindow_createFromHandle(handle, ref settings))
         {
             Initialize();
         }

--- a/src/SFML.Window/IEventMan.cs
+++ b/src/SFML.Window/IEventMan.cs
@@ -1,0 +1,21 @@
+namespace SFML.Window
+{
+    /// <summary>An instance that manages events within a SFML.Window</summary>
+    public interface IEventMan
+    {
+
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// This method is called by the window before
+        /// detecting the events from the new. Use for any
+        /// setup and cleanup of previous batch (if needed)
+        /// </summary>
+        ////////////////////////////////////////////////////////////
+        void PrepareFrame();
+        ////////////////////////////////////////////////////////////
+        /// <summary>Handles the event which was passed to it by the Window class</summary>
+        /// <param name="eve">The event object recieved</param>
+        ////////////////////////////////////////////////////////////
+        void HandleEvent(Event eve);
+    }
+}

--- a/src/SFML.Window/SubscribeManager.cs
+++ b/src/SFML.Window/SubscribeManager.cs
@@ -1,0 +1,218 @@
+using System;
+
+namespace SFML.Window
+{
+    /// <summary>
+    /// A simple Event manager that uses C# events to invoke
+    /// the required event
+    /// </summary>
+    public class SubscribeManager : IEventMan
+    {
+        public WindowBase Parent { get; set; }
+
+        ///<inheritdoc/>
+        public void PrepareFrame() { } // Nothing to do
+        ////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Call the event handler for the given event
+        /// </summary>
+        /// <param name="e">Event to dispatch</param>
+        ////////////////////////////////////////////////////////////
+        public void HandleEvent(Event e)
+        {
+            switch (e.Type)
+            {
+                case EventType.Closed:
+                    Closed?.Invoke(Parent, EventArgs.Empty);
+
+                    break;
+
+                case EventType.GainedFocus:
+                    GainedFocus?.Invoke(Parent, EventArgs.Empty);
+
+                    break;
+
+                case EventType.JoystickButtonPressed:
+                    JoystickButtonPressed?.Invoke(Parent, new JoystickButtonEventArgs(e.JoystickButton));
+
+                    break;
+
+                case EventType.JoystickButtonReleased:
+                    JoystickButtonReleased?.Invoke(Parent, new JoystickButtonEventArgs(e.JoystickButton));
+
+                    break;
+
+                case EventType.JoystickMoved:
+                    JoystickMoved?.Invoke(Parent, new JoystickMoveEventArgs(e.JoystickMove));
+
+                    break;
+
+                case EventType.JoystickConnected:
+                    JoystickConnected?.Invoke(Parent, new JoystickConnectEventArgs(e.JoystickConnect));
+
+                    break;
+
+                case EventType.JoystickDisconnected:
+                    JoystickDisconnected?.Invoke(Parent, new JoystickConnectEventArgs(e.JoystickConnect));
+
+                    break;
+
+                case EventType.KeyPressed:
+                    KeyPressed?.Invoke(Parent, new KeyEventArgs(e.Key));
+
+                    break;
+
+                case EventType.KeyReleased:
+                    KeyReleased?.Invoke(Parent, new KeyEventArgs(e.Key));
+
+                    break;
+
+                case EventType.LostFocus:
+                    LostFocus?.Invoke(Parent, EventArgs.Empty);
+
+                    break;
+
+                case EventType.MouseButtonPressed:
+                    MouseButtonPressed?.Invoke(Parent, new MouseButtonEventArgs(e.MouseButton));
+
+                    break;
+
+                case EventType.MouseButtonReleased:
+                    MouseButtonReleased?.Invoke(Parent, new MouseButtonEventArgs(e.MouseButton));
+
+                    break;
+
+                case EventType.MouseEntered:
+                    MouseEntered?.Invoke(Parent, EventArgs.Empty);
+
+                    break;
+
+                case EventType.MouseLeft:
+                    MouseLeft?.Invoke(Parent, EventArgs.Empty);
+
+                    break;
+
+                case EventType.MouseMoved:
+                    MouseMoved?.Invoke(Parent, new MouseMoveEventArgs(e.MouseMove));
+
+                    break;
+
+                // Disable CS0618 (Obselete Warning).  This Event will be removed in SFML.NET 3.0, but should remain supported until then.
+#pragma warning disable CS0618
+                case EventType.MouseWheelMoved:
+                    MouseWheelMoved?.Invoke(Parent, new MouseWheelEventArgs(e.MouseWheel));
+
+                    break;
+                // restore CS0618
+#pragma warning restore CS0618
+
+                case EventType.MouseWheelScrolled:
+                    MouseWheelScrolled?.Invoke(Parent, new MouseWheelScrollEventArgs(e.MouseWheelScroll));
+
+                    break;
+
+                case EventType.Resized:
+                    Resized?.Invoke(Parent, new SizeEventArgs(e.Size));
+
+                    break;
+
+                case EventType.TextEntered:
+                    TextEntered?.Invoke(Parent, new TextEventArgs(e.Text));
+
+                    break;
+
+                case EventType.TouchBegan:
+                    TouchBegan?.Invoke(Parent, new TouchEventArgs(e.Touch));
+
+                    break;
+
+                case EventType.TouchMoved:
+                    TouchMoved?.Invoke(Parent, new TouchEventArgs(e.Touch));
+
+                    break;
+
+                case EventType.TouchEnded:
+                    TouchEnded?.Invoke(Parent, new TouchEventArgs(e.Touch));
+
+                    break;
+
+                case EventType.SensorChanged:
+                    SensorChanged?.Invoke(Parent, new SensorEventArgs(e.Sensor));
+
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /// <summary>Event handler for the Closed event</summary>
+        public event EventHandler Closed = null;
+
+        /// <summary>Event handler for the Resized event</summary>
+        public event EventHandler<SizeEventArgs> Resized = null;
+
+        /// <summary>Event handler for the LostFocus event</summary>
+        public event EventHandler LostFocus = null;
+
+        /// <summary>Event handler for the GainedFocus event</summary>
+        public event EventHandler GainedFocus = null;
+
+        /// <summary>Event handler for the TextEntered event</summary>
+        public event EventHandler<TextEventArgs> TextEntered = null;
+
+        /// <summary>Event handler for the KeyPressed event</summary>
+        public event EventHandler<KeyEventArgs> KeyPressed = null;
+
+        /// <summary>Event handler for the KeyReleased event</summary>
+        public event EventHandler<KeyEventArgs> KeyReleased = null;
+
+        /// <summary>Event handler for the MouseWheelMoved event</summary>
+        [Obsolete("MouseWheelMoved is deprecated, please use MouseWheelScrolled instead")]
+        public event EventHandler<MouseWheelEventArgs> MouseWheelMoved = null;
+
+        /// <summary>Event handler for the MouseWheelScrolled event</summary>
+        public event EventHandler<MouseWheelScrollEventArgs> MouseWheelScrolled = null;
+
+        /// <summary>Event handler for the MouseButtonPressed event</summary>
+        public event EventHandler<MouseButtonEventArgs> MouseButtonPressed = null;
+
+        /// <summary>Event handler for the MouseButtonReleased event</summary>
+        public event EventHandler<MouseButtonEventArgs> MouseButtonReleased = null;
+
+        /// <summary>Event handler for the MouseMoved event</summary>
+        public event EventHandler<MouseMoveEventArgs> MouseMoved = null;
+
+        /// <summary>Event handler for the MouseEntered event</summary>
+        public event EventHandler MouseEntered = null;
+
+        /// <summary>Event handler for the MouseLeft event</summary>
+        public event EventHandler MouseLeft = null;
+
+        /// <summary>Event handler for the JoystickButtonPressed event</summary>
+        public event EventHandler<JoystickButtonEventArgs> JoystickButtonPressed = null;
+
+        /// <summary>Event handler for the JoystickButtonReleased event</summary>
+        public event EventHandler<JoystickButtonEventArgs> JoystickButtonReleased = null;
+
+        /// <summary>Event handler for the JoystickMoved event</summary>
+        public event EventHandler<JoystickMoveEventArgs> JoystickMoved = null;
+
+        /// <summary>Event handler for the JoystickConnected event</summary>
+        public event EventHandler<JoystickConnectEventArgs> JoystickConnected = null;
+
+        /// <summary>Event handler for the JoystickDisconnected event</summary>
+        public event EventHandler<JoystickConnectEventArgs> JoystickDisconnected = null;
+
+        /// <summary>Event handler for the TouchBegan event</summary>
+        public event EventHandler<TouchEventArgs> TouchBegan = null;
+
+        /// <summary>Event handler for the TouchMoved event</summary>
+        public event EventHandler<TouchEventArgs> TouchMoved = null;
+
+        /// <summary>Event handler for the TouchEnded event</summary>
+        public event EventHandler<TouchEventArgs> TouchEnded = null;
+
+        /// <summary>Event handler for the SensorChanged event</summary>
+        public event EventHandler<SensorEventArgs> SensorChanged = null;
+    }
+}

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -15,26 +15,15 @@ namespace SFML.Window
     {
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Create the window with default style and creation settings
-        /// </summary>
-        /// <param name="mode">Video mode to use</param>
-        /// <param name="title">Title of the window</param>
-        ////////////////////////////////////////////////////////////
-        public Window(VideoMode mode, string title) :
-            this(mode, title, Styles.Default, new ContextSettings(0, 0))
-        {
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
         /// Create the window with default creation settings
         /// </summary>
         /// <param name="mode">Video mode to use</param>
         /// <param name="title">Title of the window</param>
         /// <param name="style">Window style (Resize | Close by default)</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public Window(VideoMode mode, string title, Styles style) :
-            this(mode, title, style, new ContextSettings(0, 0))
+        public Window(VideoMode mode, string title, Styles style = Styles.Default, IEventMan manager = null) :
+            this(mode, title, style, new ContextSettings(0, 0), manager)
         {
         }
 
@@ -46,9 +35,10 @@ namespace SFML.Window
         /// <param name="title">Title of the window</param>
         /// <param name="style">Window style (Resize | Close by default)</param>
         /// <param name="settings">Creation parameters</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public Window(VideoMode mode, string title, Styles style, ContextSettings settings) :
-            base(IntPtr.Zero)
+        public Window(VideoMode mode, string title, Styles style, ContextSettings settings, IEventMan manager = null) :
+            base(IntPtr.Zero, manager)
         {
             // Copy the title to a null-terminated UTF-32 byte array
             byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0');
@@ -79,9 +69,10 @@ namespace SFML.Window
         /// </summary>
         /// <param name="Handle">Platform-specific handle of the control</param>
         /// <param name="settings">Creation parameters</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public Window(IntPtr Handle, ContextSettings settings) :
-            base(sfWindow_createFromHandle(Handle, ref settings))
+        public Window(IntPtr Handle, ContextSettings settings, IEventMan manager = null) :
+            base(sfWindow_createFromHandle(Handle, ref settings), manager)
         {
         }
 
@@ -379,14 +370,12 @@ namespace SFML.Window
         /// <summary>
         /// Constructor for derived classes
         /// </summary>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         /// <param name="cPointer">Pointer to the internal object in the C API</param>
-        /// <param name="dummy">Internal hack :)</param>
         ////////////////////////////////////////////////////////////
-        protected Window(IntPtr cPointer, int dummy) :
-            base(cPointer, 0)
-        {
-            // TODO : find a cleaner way of separating this constructor from Window(IntPtr handle)
-        }
+        protected Window(IEventMan manager, IntPtr cPointer) :
+            base(manager, cPointer)
+        { }
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.Window/WindowBase.cs
+++ b/src/SFML.Window/WindowBase.cs
@@ -45,15 +45,10 @@ namespace SFML.Window
     {
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Create the window with default style and creation settings
+        /// The event management for this window
         /// </summary>
-        /// <param name="mode">Video mode to use</param>
-        /// <param name="title">Title of the window</param>
         ////////////////////////////////////////////////////////////
-        public WindowBase(VideoMode mode, string title) :
-            this(mode, title, Styles.Default)
-        {
-        }
+        public readonly IEventMan SfmlEventManager;
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -277,10 +272,10 @@ namespace SFML.Window
         ////////////////////////////////////////////////////////////
         public void WaitAndDispatchEvents()
         {
-            Event e;
-            if (WaitEvent(out e))
+            SfmlEventManager.PrepareFrame();
+            if (WaitEvent(out Event e))
             {
-                CallEventHandler(e);
+                SfmlEventManager.HandleEvent(e);
             }
         }
 
@@ -291,10 +286,10 @@ namespace SFML.Window
         ////////////////////////////////////////////////////////////
         public void DispatchEvents()
         {
-            Event e;
-            while (PollEvent(out e))
+            SfmlEventManager.PrepareFrame();
+            while (PollEvent(out Event e))
             {
-                CallEventHandler(e);
+                SfmlEventManager.HandleEvent(e);
             }
         }
 
@@ -434,280 +429,6 @@ namespace SFML.Window
         {
             sfWindowBase_destroy(CPointer);
         }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Call the event handler for the given event
-        /// </summary>
-        /// <param name="e">Event to dispatch</param>
-        ////////////////////////////////////////////////////////////
-        private void CallEventHandler(Event e)
-        {
-            switch (e.Type)
-            {
-                case EventType.Closed:
-                    if (Closed != null)
-                    {
-                        Closed(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.GainedFocus:
-                    if (GainedFocus != null)
-                    {
-                        GainedFocus(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.JoystickButtonPressed:
-                    if (JoystickButtonPressed != null)
-                    {
-                        JoystickButtonPressed(this, new JoystickButtonEventArgs(e.JoystickButton));
-                    }
-
-                    break;
-
-                case EventType.JoystickButtonReleased:
-                    if (JoystickButtonReleased != null)
-                    {
-                        JoystickButtonReleased(this, new JoystickButtonEventArgs(e.JoystickButton));
-                    }
-
-                    break;
-
-                case EventType.JoystickMoved:
-                    if (JoystickMoved != null)
-                    {
-                        JoystickMoved(this, new JoystickMoveEventArgs(e.JoystickMove));
-                    }
-
-                    break;
-
-                case EventType.JoystickConnected:
-                    if (JoystickConnected != null)
-                    {
-                        JoystickConnected(this, new JoystickConnectEventArgs(e.JoystickConnect));
-                    }
-
-                    break;
-
-                case EventType.JoystickDisconnected:
-                    if (JoystickDisconnected != null)
-                    {
-                        JoystickDisconnected(this, new JoystickConnectEventArgs(e.JoystickConnect));
-                    }
-
-                    break;
-
-                case EventType.KeyPressed:
-                    if (KeyPressed != null)
-                    {
-                        KeyPressed(this, new KeyEventArgs(e.Key));
-                    }
-
-                    break;
-
-                case EventType.KeyReleased:
-                    if (KeyReleased != null)
-                    {
-                        KeyReleased(this, new KeyEventArgs(e.Key));
-                    }
-
-                    break;
-
-                case EventType.LostFocus:
-                    if (LostFocus != null)
-                    {
-                        LostFocus(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.MouseButtonPressed:
-                    if (MouseButtonPressed != null)
-                    {
-                        MouseButtonPressed(this, new MouseButtonEventArgs(e.MouseButton));
-                    }
-
-                    break;
-
-                case EventType.MouseButtonReleased:
-                    if (MouseButtonReleased != null)
-                    {
-                        MouseButtonReleased(this, new MouseButtonEventArgs(e.MouseButton));
-                    }
-
-                    break;
-
-                case EventType.MouseEntered:
-                    if (MouseEntered != null)
-                    {
-                        MouseEntered(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.MouseLeft:
-                    if (MouseLeft != null)
-                    {
-                        MouseLeft(this, EventArgs.Empty);
-                    }
-
-                    break;
-
-                case EventType.MouseMoved:
-                    if (MouseMoved != null)
-                    {
-                        MouseMoved(this, new MouseMoveEventArgs(e.MouseMove));
-                    }
-
-                    break;
-
-                // Disable CS0618 (Obselete Warning).  This Event will be removed in SFML.NET 3.0, but should remain supported until then.
-#pragma warning disable CS0618
-                case EventType.MouseWheelMoved:
-                    if (MouseWheelMoved != null)
-                    {
-                        MouseWheelMoved(this, new MouseWheelEventArgs(e.MouseWheel));
-                    }
-
-                    break;
-                // restore CS0618
-#pragma warning restore CS0618
-
-                case EventType.MouseWheelScrolled:
-                    if (MouseWheelScrolled != null)
-                    {
-                        MouseWheelScrolled(this, new MouseWheelScrollEventArgs(e.MouseWheelScroll));
-                    }
-
-                    break;
-
-                case EventType.Resized:
-                    if (Resized != null)
-                    {
-                        Resized(this, new SizeEventArgs(e.Size));
-                    }
-
-                    break;
-
-                case EventType.TextEntered:
-                    if (TextEntered != null)
-                    {
-                        TextEntered(this, new TextEventArgs(e.Text));
-                    }
-
-                    break;
-
-                case EventType.TouchBegan:
-                    if (TouchBegan != null)
-                    {
-                        TouchBegan(this, new TouchEventArgs(e.Touch));
-                    }
-
-                    break;
-
-                case EventType.TouchMoved:
-                    if (TouchMoved != null)
-                    {
-                        TouchMoved(this, new TouchEventArgs(e.Touch));
-                    }
-
-                    break;
-
-                case EventType.TouchEnded:
-                    if (TouchEnded != null)
-                    {
-                        TouchEnded(this, new TouchEventArgs(e.Touch));
-                    }
-
-                    break;
-
-                case EventType.SensorChanged:
-                    if (SensorChanged != null)
-                    {
-                        SensorChanged(this, new SensorEventArgs(e.Sensor));
-                    }
-
-                    break;
-
-                default:
-                    break;
-            }
-        }
-
-        /// <summary>Event handler for the Closed event</summary>
-        public event EventHandler Closed = null;
-
-        /// <summary>Event handler for the Resized event</summary>
-        public event EventHandler<SizeEventArgs> Resized = null;
-
-        /// <summary>Event handler for the LostFocus event</summary>
-        public event EventHandler LostFocus = null;
-
-        /// <summary>Event handler for the GainedFocus event</summary>
-        public event EventHandler GainedFocus = null;
-
-        /// <summary>Event handler for the TextEntered event</summary>
-        public event EventHandler<TextEventArgs> TextEntered = null;
-
-        /// <summary>Event handler for the KeyPressed event</summary>
-        public event EventHandler<KeyEventArgs> KeyPressed = null;
-
-        /// <summary>Event handler for the KeyReleased event</summary>
-        public event EventHandler<KeyEventArgs> KeyReleased = null;
-
-        /// <summary>Event handler for the MouseWheelMoved event</summary>
-        [Obsolete("Use MouseWheelScrolled")]
-        public event EventHandler<MouseWheelEventArgs> MouseWheelMoved = null;
-
-        /// <summary>Event handler for the MouseWheelScrolled event</summary>
-        public event EventHandler<MouseWheelScrollEventArgs> MouseWheelScrolled = null;
-
-        /// <summary>Event handler for the MouseButtonPressed event</summary>
-        public event EventHandler<MouseButtonEventArgs> MouseButtonPressed = null;
-
-        /// <summary>Event handler for the MouseButtonReleased event</summary>
-        public event EventHandler<MouseButtonEventArgs> MouseButtonReleased = null;
-
-        /// <summary>Event handler for the MouseMoved event</summary>
-        public event EventHandler<MouseMoveEventArgs> MouseMoved = null;
-
-        /// <summary>Event handler for the MouseEntered event</summary>
-        public event EventHandler MouseEntered = null;
-
-        /// <summary>Event handler for the MouseLeft event</summary>
-        public event EventHandler MouseLeft = null;
-
-        /// <summary>Event handler for the JoystickButtonPressed event</summary>
-        public event EventHandler<JoystickButtonEventArgs> JoystickButtonPressed = null;
-
-        /// <summary>Event handler for the JoystickButtonReleased event</summary>
-        public event EventHandler<JoystickButtonEventArgs> JoystickButtonReleased = null;
-
-        /// <summary>Event handler for the JoystickMoved event</summary>
-        public event EventHandler<JoystickMoveEventArgs> JoystickMoved = null;
-
-        /// <summary>Event handler for the JoystickConnected event</summary>
-        public event EventHandler<JoystickConnectEventArgs> JoystickConnected = null;
-
-        /// <summary>Event handler for the JoystickDisconnected event</summary>
-        public event EventHandler<JoystickConnectEventArgs> JoystickDisconnected = null;
-
-        /// <summary>Event handler for the TouchBegan event</summary>
-        public event EventHandler<TouchEventArgs> TouchBegan = null;
-
-        /// <summary>Event handler for the TouchMoved event</summary>
-        public event EventHandler<TouchEventArgs> TouchMoved = null;
-
-        /// <summary>Event handler for the TouchEnded event</summary>
-        public event EventHandler<TouchEventArgs> TouchEnded = null;
-
-        /// <summary>Event handler for the SensorChanged event</summary>
-        public event EventHandler<SensorEventArgs> SensorChanged = null;
-
         #region Imports
         [DllImport(CSFML.window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]
         private static extern IntPtr sfWindowBase_create(VideoMode Mode, string Title, Styles Style);

--- a/src/SFML.Window/WindowBase.cs
+++ b/src/SFML.Window/WindowBase.cs
@@ -57,8 +57,9 @@ namespace SFML.Window
         /// <param name="mode">Video mode to use</param>
         /// <param name="title">Title of the window</param>
         /// <param name="style">Window style (Resize | Close by default)</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public WindowBase(VideoMode mode, string title, Styles style) :
+        public WindowBase(VideoMode mode, string title, Styles style = Styles.Default, IEventMan manager = null) :
             base(IntPtr.Zero)
         {
             // Copy the title to a null-terminated UTF-32 byte array
@@ -71,6 +72,11 @@ namespace SFML.Window
                     CPointer = sfWindowBase_createUnicode(mode, (IntPtr)titlePtr, style);
                 }
             }
+            if (manager == null)
+            {
+                manager = new SubscribeManager() { Parent = this };
+            }
+            SfmlEventManager = manager;
         }
 
         ////////////////////////////////////////////////////////////
@@ -78,10 +84,16 @@ namespace SFML.Window
         /// Create the window from an existing control
         /// </summary>
         /// <param name="Handle">Platform-specific handle of the control</param>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         ////////////////////////////////////////////////////////////
-        public WindowBase(IntPtr Handle) :
+        public WindowBase(IntPtr Handle, IEventMan manager = null) :
             base(sfWindowBase_createFromHandle(Handle))
         {
+            if (manager == null)
+            {
+                manager = new SubscribeManager() { Parent = this };
+            }
+            SfmlEventManager = manager;
         }
 
         ////////////////////////////////////////////////////////////
@@ -346,13 +358,17 @@ namespace SFML.Window
         /// <summary>
         /// Constructor for derived classes
         /// </summary>
+        /// <param name="manager">A custom event manager. By default, a SubscribeManager object is created</param>
         /// <param name="cPointer">Pointer to the internal object in the C API</param>
-        /// <param name="dummy">Internal hack :)</param>
         ////////////////////////////////////////////////////////////
-        protected WindowBase(IntPtr cPointer, int dummy) :
+        protected WindowBase(IEventMan manager, IntPtr cPointer) :
             base(cPointer)
         {
-            // TODO : find a cleaner way of separating this constructor from WindowBase(IntPtr handle)
+            if (manager == null)
+            {
+                manager = new SubscribeManager() { Parent = this };
+            }
+            SfmlEventManager = manager;
         }
 
         ////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Summary of PR
This PR introduces a new approach to SFML event management. Prior to this, the C# events within the `WindowBase` class are required to be subscribed to .NET events within the `WindowBase` class. This PR makes the class `WindowBase` to hold an object of `IEventMan`, and the `WindowBase.DispatchEvents()` now passes all events to this `IEventMan` object. Thus, the developer can now define their own event management logic using Dependancy Injection of their own custom type which implements this interface.

The interface `IEventMan` defines two methods.

```csharp
public interface IEventMan
{
    void PrepareFrame();          // To be called once every frame, before events are processed
    void HandleEvent(Event eve);  // Passes the event to the custom logic
}
``` 
and the class `WindowBase` is modifed as 

```csharp
public class WindowBase : ObjectBase
{
    public readonly IEventMan SfmlEventManager;
    ...

    public void DispatchEvents()
    {
        SfmlEventManager.PrepareFrame();
        while (PollEvent(out Event e))
        {
            SfmlEventManager.HandleEvent(e);
        }
    }
``` 

Thus, a custom logic for event handling can be provided as shown

```csharp
public struct SimpleEventPasser : IEventMan
{
    private readonly List<Event> _events;
    public SimpleEventPasser() => _events = new();
    public void HandleEvent(Event eve)
    {
        switch (eve.Type)
        {
            case EventType.Closed:
            case EventType.LostFocus:
            case EventType.GainedFocus:
            case EventType.KeyPressed:
            case EventType.KeyReleased:
                _events.Add(eve);
                break;
            default: // Filtering out all other events
                break;
        }
    }
    public void PrepareFrame() => _events.Clear();
    public IEnumerable<Event> ProcessEvents() => _events;
}
public static class Program
{
    public static void Main()
    {
        var event_man = new SimpleEventPasser();
        var window = new RenderWindow(
            new(640, 480),
            "Custom Event Manager example",
            Styles.Default,
            event_man
        );
        while (window.IsOpen)
        {
            window.Clear(Color.Black);
            window.DispatchEvents();
            window.Display();
            foreach (var e in event_man.ProcessEvents())
            {
                System.Console.WriteLine(e.ToString());
                if (e.Type == EventType.Closed)
                {
                    window.Close();
                }
            }
        }
    }
}
```
The above example is also added in a new project in the `examples` folder.

The original .NET event based implementation is separated to a class `SubscribeManager`. This is set to be the default object created for `WindowBase`. This does make it to be a breaking change, and the examples are also modified to support them.

Also, as a small bonus, the dummy values in the constructors are resolved. Since the constructors of base class `WindowBase` now also accept a type of `IEventMan`, all public and protected constructors can be differentiated by the order of the arguements.

# Details of commits
The first commit defines `IEventMan`, along with modifying the `WindowBase` class. The original implementation of event handling is moved to the class `SubscribeManager`.

The second commit modifies the constructor to accept an argument of the type `IEventMan`, which would be used by the `WindowBase`. This commit also resolves the public and protected constructors so that the dummy variables are not needed.

The third commit modifies the examples to build sucessfully. Also, a new example `custom_eventman` is added. All examples are tested on linux, by running them in `net6.0` framework.