### PR TITLE
Use fixed version for CSFML

### DIFF
--- a/SFML.Module.props
+++ b/SFML.Module.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSFML" Version="2.6.1" />
+    <PackageReference Include="CSFML" Version="[2.6.1, 2.7)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This theoretically prevents users from accidentally updating CSFML to a newer version from the NuGet Updates tab. It doesn't stop them from forcefully installing a newer version of CSFML as per <https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#direct-dependency-wins>.