### PR TITLE
Use Span for SFML.Net API

### DIFF
--- a/SFML.Module.props
+++ b/SFML.Module.props
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="CSFML" Version="[2.6.1, 2.7)" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
 </Project>

--- a/examples/opengl/OpenGL.cs
+++ b/examples/opengl/OpenGL.cs
@@ -54,7 +54,7 @@ namespace opengl
             {
                 GL.GenTextures(1, out texture);
                 GL.BindTexture(TextureTarget.Texture2D, texture);
-                GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, (int)image.Size.X, (int)image.Size.Y, 0, PixelFormat.Rgba, PixelType.UnsignedByte, image.Pixels);
+                GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, (int)image.Size.X, (int)image.Size.Y, 0, PixelFormat.Rgba, PixelType.UnsignedByte, image.Pixels.ToArray());
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
             }

--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -71,18 +71,17 @@ namespace SFML.Audio
         /// <param name="bytes">Byte array containing the file contents</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Music(byte[] bytes) :
+        public Music(Span<byte> bytes) :
             base(IntPtr.Zero)
         {
-            GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            try
+            unsafe
             {
-                CPointer = sfMusic_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
+                fixed (byte* ptr = bytes)
+                {
+                    CPointer = sfMusic_createFromMemory((IntPtr)ptr, (UIntPtr)bytes.Length);
+                }
             }
-            finally
-            {
-                pin.Free();
-            }
+
             if (CPointer == IntPtr.Zero)
             {
                 throw new LoadingFailedException("music");

--- a/src/SFML.Audio/SoundBufferRecorder.cs
+++ b/src/SFML.Audio/SoundBufferRecorder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SFML.Audio
@@ -57,9 +58,14 @@ namespace SFML.Audio
         /// <param name="samples">Array of samples to process</param>
         /// <returns>False to stop recording audio data, true to continue</returns>
         ////////////////////////////////////////////////////////////
-        protected override bool OnProcessSamples(short[] samples)
+        protected override bool OnProcessSamples(Span<short> samples)
         {
-            mySamplesArray.AddRange(samples);
+            if (mySamplesArray.Capacity < mySamplesArray.Count + samples.Length)
+                mySamplesArray.Capacity = mySamplesArray.Count + samples.Length;
+
+            for (int i = 0; i < samples.Length; i++)
+                mySamplesArray.Add(samples[i]);
+
             return true;
         }
 

--- a/src/SFML.Audio/SoundRecorder.cs
+++ b/src/SFML.Audio/SoundRecorder.cs
@@ -158,7 +158,7 @@ namespace SFML.Audio
         /// <param name="samples">Array of samples to process</param>
         /// <returns>False to stop recording audio data, true to continue</returns>
         ////////////////////////////////////////////////////////////
-        protected abstract bool OnProcessSamples(short[] samples);
+        protected abstract bool OnProcessSamples(Span<short> samples);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -286,10 +286,10 @@ namespace SFML.Audio
         ////////////////////////////////////////////////////////////
         private bool ProcessSamples(IntPtr samples, UIntPtr nbSamples, IntPtr userData)
         {
-            short[] samplesArray = new short[(int)nbSamples];
-            Marshal.Copy(samples, samplesArray, 0, samplesArray.Length);
-
-            return OnProcessSamples(samplesArray);
+            unsafe
+            {
+                return OnProcessSamples(new Span<short>((void*)samples, (int)nbSamples));
+            }
         }
 
         ////////////////////////////////////////////////////////////

--- a/src/SFML.Graphics/Font.cs
+++ b/src/SFML.Graphics/Font.cs
@@ -59,18 +59,17 @@ namespace SFML.Graphics
         /// <param name="bytes">Byte array containing the file contents</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Font(byte[] bytes) :
+        public Font(Span<byte> bytes) :
             base(IntPtr.Zero)
         {
-            GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            try
+            unsafe
             {
-                CPointer = sfFont_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
+                fixed (byte* ptr = bytes)
+                {
+                    CPointer = sfFont_createFromMemory((IntPtr)ptr, (UIntPtr)bytes.Length);
+                }
             }
-            finally
-            {
-                pin.Free();
-            }
+
             if (CPointer == IntPtr.Zero)
             {
                 throw new LoadingFailedException("font");

--- a/src/SFML.Graphics/RenderTarget.cs
+++ b/src/SFML.Graphics/RenderTarget.cs
@@ -1,3 +1,4 @@
+using System;
 using SFML.System;
 
 namespace SFML.Graphics
@@ -179,7 +180,7 @@ namespace SFML.Graphics
         /// <param name="vertices">Array of vertices to draw</param>
         /// <param name="type">Type of primitives to draw</param>
         ////////////////////////////////////////////////////////////
-        void Draw(Vertex[] vertices, PrimitiveType type);
+        void Draw(Span<Vertex> vertices, PrimitiveType type);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -189,30 +190,7 @@ namespace SFML.Graphics
         /// <param name="type">Type of primitives to draw</param>
         /// <param name="states">Render states to use for drawing</param>
         ////////////////////////////////////////////////////////////
-        void Draw(Vertex[] vertices, PrimitiveType type, RenderStates states);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices, with default render states
-        /// </summary>
-        /// <param name="vertices">Array of vertices to draw</param>
-        /// <param name="start">Index of the first vertex to draw in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        ////////////////////////////////////////////////////////////
-        void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices
-        /// </summary>
-        /// <param name="vertices">Pointer to the vertices</param>
-        /// <param name="start">Index of the first vertex to use in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        /// <param name="states">Render states to use for drawing</param>
-        ////////////////////////////////////////////////////////////
-        void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type, RenderStates states);
+        void Draw(Span<Vertex> vertices, PrimitiveType type, RenderStates states);
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -360,7 +360,7 @@ namespace SFML.Graphics
         /// <param name="vertices">Pointer to the vertices</param>
         /// <param name="type">Type of primitives to draw</param>
         ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, PrimitiveType type)
+        public void Draw(Span<Vertex> vertices, PrimitiveType type)
         {
             Draw(vertices, type, RenderStates.Default);
         }
@@ -373,36 +373,7 @@ namespace SFML.Graphics
         /// <param name="type">Type of primitives to draw</param>
         /// <param name="states">Render states to use for drawing</param>
         ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, PrimitiveType type, RenderStates states)
-        {
-            Draw(vertices, 0, (uint)vertices.Length, type, states);
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices, with default render states
-        /// </summary>
-        /// <param name="vertices">Array of vertices to draw</param>
-        /// <param name="start">Index of the first vertex to draw in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type)
-        {
-            Draw(vertices, start, count, type, RenderStates.Default);
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices
-        /// </summary>
-        /// <param name="vertices">Pointer to the vertices</param>
-        /// <param name="start">Index of the first vertex to use in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        /// <param name="states">Render states to use for drawing</param>
-        ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type, RenderStates states)
+        public void Draw(Span<Vertex> vertices, PrimitiveType type, RenderStates states)
         {
             RenderStates.MarshalData marshaledStates = states.Marshal();
 
@@ -410,7 +381,7 @@ namespace SFML.Graphics
             {
                 fixed (Vertex* vertexPtr = vertices)
                 {
-                    sfRenderTexture_drawPrimitives(CPointer, vertexPtr + start, (UIntPtr)count, type, ref marshaledStates);
+                    sfRenderTexture_drawPrimitives(CPointer, vertexPtr, (UIntPtr)vertices.Length, type, ref marshaledStates);
                 }
             }
         }

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -184,13 +184,13 @@ namespace SFML.Graphics
         /// <param name="height">Icon's height, in pixels</param>
         /// <param name="pixels">Array of pixels, format must be RGBA 32 bits</param>
         ////////////////////////////////////////////////////////////
-        public override void SetIcon(uint width, uint height, byte[] pixels)
+        public override void SetIcon(uint width, uint height, Span<byte> pixels)
         {
             unsafe
             {
-                fixed (byte* PixelsPtr = pixels)
+                fixed (byte* ptr = pixels)
                 {
-                    sfRenderWindow_setIcon(CPointer, width, height, PixelsPtr);
+                    sfRenderWindow_setIcon(CPointer, width, height, ptr);
                 }
             }
         }
@@ -552,7 +552,7 @@ namespace SFML.Graphics
         /// <param name="vertices">Pointer to the vertices</param>
         /// <param name="type">Type of primitives to draw</param>
         ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, PrimitiveType type)
+        public void Draw(Span<Vertex> vertices, PrimitiveType type)
         {
             Draw(vertices, type, RenderStates.Default);
         }
@@ -565,36 +565,7 @@ namespace SFML.Graphics
         /// <param name="type">Type of primitives to draw</param>
         /// <param name="states">Render states to use for drawing</param>
         ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, PrimitiveType type, RenderStates states)
-        {
-            Draw(vertices, 0, (uint)vertices.Length, type, states);
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices, with default render states
-        /// </summary>
-        /// <param name="vertices">Array of vertices to draw</param>
-        /// <param name="start">Index of the first vertex to draw in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type)
-        {
-            Draw(vertices, start, count, type, RenderStates.Default);
-        }
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices
-        /// </summary>
-        /// <param name="vertices">Pointer to the vertices</param>
-        /// <param name="start">Index of the first vertex to use in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        /// <param name="states">Render states to use for drawing</param>
-        ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type, RenderStates states)
+        public void Draw(Span<Vertex> vertices, PrimitiveType type, RenderStates states)
         {
             RenderStates.MarshalData marshaledStates = states.Marshal();
 
@@ -602,7 +573,7 @@ namespace SFML.Graphics
             {
                 fixed (Vertex* vertexPtr = vertices)
                 {
-                    sfRenderWindow_drawPrimitives(CPointer, vertexPtr + start, (UIntPtr)count, type, ref marshaledStates);
+                    sfRenderWindow_drawPrimitives(CPointer, vertexPtr, (UIntPtr)vertices.Length, type, ref marshaledStates);
                 }
             }
         }

--- a/src/SFML.Graphics/Shader.cs
+++ b/src/SFML.Graphics/Shader.cs
@@ -402,7 +402,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>float</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, float[] array)
+        public unsafe void SetUniformArray(string name, Span<float> array)
         {
             fixed (float* data = array)
             {
@@ -417,7 +417,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>vec2</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Vec2[] array)
+        public unsafe void SetUniformArray(string name, Span<Glsl.Vec2> array)
         {
             fixed (Glsl.Vec2* data = array)
             {
@@ -432,7 +432,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>vec3</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Vec3[] array)
+        public unsafe void SetUniformArray(string name, Span<Glsl.Vec3> array)
         {
             fixed (Glsl.Vec3* data = array)
             {
@@ -447,7 +447,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>vec4</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Vec4[] array)
+        public unsafe void SetUniformArray(string name, Span<Glsl.Vec4> array)
         {
             fixed (Glsl.Vec4* data = array)
             {
@@ -462,7 +462,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>mat3</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Mat3[] array)
+        public unsafe void SetUniformArray(string name, Span<Glsl.Mat3> array)
         {
             fixed (Glsl.Mat3* data = array)
             {
@@ -477,7 +477,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>mat4</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Mat4[] array)
+        public unsafe void SetUniformArray(string name, Span<Glsl.Mat4> array)
         {
             fixed (Glsl.Mat4* data = array)
             {

--- a/src/SFML.Graphics/Text.cs
+++ b/src/SFML.Graphics/Text.cs
@@ -190,12 +190,11 @@ namespace SFML.Graphics
                     }
                 }
 
-                // Copy it to a byte array
-                byte[] sourceBytes = new byte[length * 4];
-                Marshal.Copy(source, sourceBytes, 0, sourceBytes.Length);
-
                 // Convert it to a C# string
-                return Encoding.UTF32.GetString(sourceBytes);
+                unsafe
+                {
+                    return Encoding.UTF32.GetString((byte*)source, (int)( length * 4 ));
+                }
             }
 
             set

--- a/src/SFML.Graphics/VertexBuffer.cs
+++ b/src/SFML.Graphics/VertexBuffer.cs
@@ -143,7 +143,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Update the <see cref="VertexBuffer"/> from a <see cref="Vertex"/>[]
+        /// Update the <see cref="VertexBuffer"/> from a <see cref="Span{Vertex}"/>[]
         /// </summary>
         /// <remarks>
         /// <para>
@@ -178,7 +178,7 @@ namespace SFML.Graphics
         /// <param name="vertexCount">Number of vertices to copy</param>
         /// <param name="offset">Offset in the buffer to copy to</param>
         ////////////////////////////////////////////////////////////
-        public bool Update(Vertex[] vertices, uint vertexCount, uint offset)
+        public bool Update(Span<Vertex> vertices, uint vertexCount, uint offset)
         {
             unsafe
             {
@@ -215,7 +215,7 @@ namespace SFML.Graphics
         /// </remarks>
         /// <param name="vertices">Array of vertices to copy to the buffer</param>
         ////////////////////////////////////////////////////////////
-        public bool Update(Vertex[] vertices)
+        public bool Update(Span<Vertex> vertices)
         {
             return this.Update(vertices, (uint)vertices.Length, 0);
         }
@@ -256,7 +256,7 @@ namespace SFML.Graphics
         /// <param name="vertices">Array of vertices to copy to the buffer</param>
         /// <param name="offset">Offset in the buffer to copy to</param>
         ////////////////////////////////////////////////////////////
-        public bool Update(Vertex[] vertices, uint offset)
+        public bool Update(Span<Vertex> vertices, uint offset)
         {
             return this.Update(vertices, (uint)vertices.Length, offset);
         }

--- a/src/SFML.Window/Clipboard.cs
+++ b/src/SFML.Window/Clipboard.cs
@@ -29,10 +29,10 @@ namespace SFML.Window
                     }
                 }
                 
-                byte[] sourceBytes = new byte[length * 4];
-                Marshal.Copy(source, sourceBytes, 0, sourceBytes.Length);
-                
-                return Encoding.UTF32.GetString(sourceBytes);
+                unsafe
+                {
+                    return Encoding.UTF32.GetString((byte*)source, (int)( length * 4 ));
+                }
             }
             set
             {

--- a/src/SFML.Window/Cursor.cs
+++ b/src/SFML.Window/Cursor.cs
@@ -214,7 +214,7 @@ namespace SFML.Window
         /// <param name="size">Width and height of the image</param>
         /// <param name="hotspot">(x,y) location of the hotspot</param>
         /// <exception cref="LoadingFailedException" />
-        public Cursor(byte[] pixels, SFML.System.Vector2u size, SFML.System.Vector2u hotspot)
+        public Cursor(Span<byte> pixels, SFML.System.Vector2u size, SFML.System.Vector2u hotspot)
             : base((IntPtr)0)
         {
             unsafe

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -180,13 +180,13 @@ namespace SFML.Window
         /// <param name="height">Icon's height, in pixels</param>
         /// <param name="pixels">Array of pixels, format must be RGBA 32 bits</param>
         ////////////////////////////////////////////////////////////
-        public override void SetIcon(uint width, uint height, byte[] pixels)
+        public override void SetIcon(uint width, uint height, Span<byte> pixels)
         {
             unsafe
             {
-                fixed (byte* PixelsPtr = pixels)
+                fixed (byte* ptr = pixels)
                 {
-                    sfWindow_setIcon(CPointer, width, height, PixelsPtr);
+                    sfWindow_setIcon(CPointer, width, height, ptr);
                 }
             }
         }

--- a/src/SFML.Window/WindowBase.cs
+++ b/src/SFML.Window/WindowBase.cs
@@ -164,13 +164,13 @@ namespace SFML.Window
         /// <param name="height">Icon's height, in pixels</param>
         /// <param name="pixels">Array of pixels, format must be RGBA 32 bits</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetIcon(uint width, uint height, byte[] pixels)
+        public virtual void SetIcon(uint width, uint height, Span<byte> pixels)
         {
             unsafe
             {
-                fixed (byte* PixelsPtr = pixels)
+                fixed (byte* ptr = pixels)
                 {
-                    sfWindowBase_setIcon(CPointer, width, height, PixelsPtr);
+                    sfWindowBase_setIcon(CPointer, width, height, ptr);
                 }
             }
         }


### PR DESCRIPTION
Making this draft as a starting point for Span-related changes. This might also be a good place to look over some memory allocations happening in the library. The idea is as follows:
- Use System.Memory to gain access to Span<T>, which is usable in .NET Standard 2.0
- Replace T[] with Span<T> in input parameters where possible - this is a trivial change that just allows slicing
- Replace T[] returns with Span<T> where possible (i.e. when we want to just give a view into memory) - this reduces the number of allocations and solves some anti-patterns like `Image.Pixels`

In some cases it's harder to use Span<T> due to lack of methods that are available only in .NET Core. One such example is StreamAdaptor where you cannot read into a Span<byte>.

I'm also thinking we could use `stackalloc` for places that use patterns like `byte[] titleAsUtf32 = Encoding.UTF32.GetBytes(title + '\0')`. There is an overload for `GetBytes` that can work with pointers, which could be used together with `stackalloc` for small-sized strings to avoid allocating small temporary strings on the heap.