### PR TITLE
Add tuple support for vector, rectangle and color structs

### DIFF
--- a/src/SFML.Graphics/Color.cs
+++ b/src/SFML.Graphics/Color.cs
@@ -79,6 +79,21 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public override string ToString() => $"[Color] R({R}) G({G}) B({B}) A({A})";
 
+        /// <summary>
+        /// Deconstructs a Color into a tuple of bytes
+        /// </summary>
+        /// <param name="red">Red component</param>
+        /// <param name="green">Green component</param>
+        /// <param name="blue">Blue component</param>
+        /// <param name="alpha">Alpha (transparency) component</param>
+        public void Deconstruct(out byte red, out byte green, out byte blue, out byte alpha)
+        {
+            red = R;
+            green = G;
+            blue = B;
+            alpha = A;
+        }
+
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Compare color and object and checks if they are equal
@@ -165,6 +180,12 @@ namespace SFML.Graphics
                              (byte)( left.B * right.B / 255 ),
                              (byte)( left.A * right.A / 255 ));
         }
+
+        /// <summary>
+        /// Converts a tuple of bytes to a Color
+        /// </summary>
+        /// <param name="tuple">The tuple to convert</param>
+        public static implicit operator Color((byte R, byte G, byte B, byte A) tuple) => new Color(tuple.R, tuple.G, tuple.B, tuple.A);
 
         /// <summary>Red component of the color</summary>
         public byte R;

--- a/src/SFML.Graphics/Rect.cs
+++ b/src/SFML.Graphics/Rect.cs
@@ -177,6 +177,21 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public Vector2i Size => new Vector2i(Width, Height);
 
+        /// <summary>
+        /// Deconstructs an IntRect into a tuple of ints
+        /// </summary>
+        /// <param name="left">Left coordinate of the rectangle</param>
+        /// <param name="top">Top coordinate of the rectangle</param>
+        /// <param name="width">Width of the rectangle</param>
+        /// <param name="height">Height of the rectangle</param>
+        public void Deconstruct(out int left, out int top, out int width, out int height)
+        {
+            left = Left;
+            top = Top;
+            width = Width;
+            height = Height;
+        }
+
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Provide a string describing the object
@@ -245,6 +260,12 @@ namespace SFML.Graphics
         /// <returns>r1 != r2</returns>
         ////////////////////////////////////////////////////////////
         public static bool operator !=(IntRect r1, IntRect r2) => !r1.Equals(r2);
+
+        /// <summary>
+        /// Converts a tuple of ints to an IntRect
+        /// </summary>
+        /// <param name="tuple">The tuple to convert</param>
+        public static implicit operator IntRect((int Left, int Top, int Width, int Height) tuple) => new IntRect(tuple.Left, tuple.Top, tuple.Width, tuple.Height);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -445,6 +466,21 @@ namespace SFML.Graphics
         ////////////////////////////////////////////////////////////
         public Vector2f Size => new Vector2f(Width, Height);
 
+        /// <summary>
+        /// Deconstructs a FloatRect into a tuple of floats
+        /// </summary>
+        /// <param name="left">Left coordinate of the rectangle</param>
+        /// <param name="top">Top coordinate of the rectangle</param>
+        /// <param name="width">Width of the rectangle</param>
+        /// <param name="height">Height of the rectangle</param>
+        public void Deconstruct(out float left, out float top, out float width, out float height)
+        {
+            left = Left;
+            top = Top;
+            width = Width;
+            height = Height;
+        }
+
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Provide a string describing the object
@@ -526,6 +562,12 @@ namespace SFML.Graphics
         {
             return !r1.Equals(r2);
         }
+
+        /// <summary>
+        /// Converts a tuple of floats to a FloatRect
+        /// </summary>
+        /// <param name="tuple">The tuple to convert</param>
+        public static implicit operator FloatRect((float Left, float Top, float Width, float Height) tuple) => new FloatRect(tuple.Left, tuple.Top, tuple.Width, tuple.Height);
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.System/Vector2.cs
+++ b/src/SFML.System/Vector2.cs
@@ -25,6 +25,17 @@ namespace SFML.System
             Y = y;
         }
 
+        /// <summary>
+        /// Deconstructs a Vector2f into a tuple of floats
+        /// </summary>
+        /// <param name="x">X coordinate</param>
+        /// <param name="y">Y coordinate</param>
+        public void Deconstruct(out float x, out float y)
+        {
+            x = X;
+            y = Y;
+        }
+
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Operator - overload ; returns the opposite of a vector
@@ -156,6 +167,12 @@ namespace SFML.System
         ////////////////////////////////////////////////////////////
         public static explicit operator Vector2u(Vector2f v) => new Vector2u((uint)v.X, (uint)v.Y);
 
+        /// <summary>
+        /// Converts a tuple of floats to a Vector2f
+        /// </summary>
+        /// <param name="tuple">The tuple to convert</param>
+        public static implicit operator Vector2f((float X, float Y) tuple) => new Vector2f(tuple.X, tuple.Y);
+
         /// <summary>X (horizontal) component of the vector</summary>
         public float X;
 
@@ -183,6 +200,17 @@ namespace SFML.System
         {
             X = x;
             Y = y;
+        }
+
+        /// <summary>
+        /// Deconstructs a Vector2i into a tuple of ints
+        /// </summary>
+        /// <param name="x">X coordinate</param>
+        /// <param name="y">Y coordinate</param>
+        public void Deconstruct(out int x, out int y)
+        {
+            x = X;
+            y = Y;
         }
 
         ////////////////////////////////////////////////////////////
@@ -316,6 +344,12 @@ namespace SFML.System
         ////////////////////////////////////////////////////////////
         public static explicit operator Vector2u(Vector2i v) => new Vector2u((uint)v.X, (uint)v.Y);
 
+        /// <summary>
+        /// Converts a tuple of ints to a Vector2i
+        /// </summary>
+        /// <param name="tuple">The tuple to convert</param>
+        public static implicit operator Vector2i((int X, int Y) tuple) => new Vector2i(tuple.X, tuple.Y);
+
         /// <summary>X (horizontal) component of the vector</summary>
         public int X;
 
@@ -343,6 +377,17 @@ namespace SFML.System
         {
             X = x;
             Y = y;
+        }
+
+        /// <summary>
+        /// Deconstructs a Vector2u into a tuple of uints
+        /// </summary>
+        /// <param name="x">X coordinate</param>
+        /// <param name="y">Y coordinate</param>
+        public void Deconstruct(out uint x, out uint y)
+        {
+            x = X;
+            y = Y;
         }
 
         ////////////////////////////////////////////////////////////
@@ -466,6 +511,12 @@ namespace SFML.System
         /// <returns>Casting result</returns>
         ////////////////////////////////////////////////////////////
         public static explicit operator Vector2f(Vector2u v) => new Vector2f(v.X, v.Y);
+
+        /// <summary>
+        /// Converts a tuple of uints to a Vector2u
+        /// </summary>
+        /// <param name="tuple">The tuple to convert</param>
+        public static implicit operator Vector2u((uint X, uint Y) tuple) => new Vector2u(tuple.X, tuple.Y);
 
         /// <summary>X (horizontal) component of the vector</summary>
         public uint X;

--- a/src/SFML.System/Vector3.cs
+++ b/src/SFML.System/Vector3.cs
@@ -27,6 +27,19 @@ namespace SFML.System
             Z = z;
         }
 
+        /// <summary>
+        /// Deconstructs a Vector3f into a tuple of floats
+        /// </summary>
+        /// <param name="x">X coordinate</param>
+        /// <param name="y">Y coordinate</param>
+        /// <param name="z">Z coordinate</param>
+        public void Deconstruct(out float x, out float y, out float z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+        }
+
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Operator - overload ; returns the opposite of a vector
@@ -139,6 +152,12 @@ namespace SFML.System
         /// <returns>Integer description of the object</returns>
         ////////////////////////////////////////////////////////////
         public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
+
+        /// <summary>
+        /// Converts a tuple of floats to a Vector3f
+        /// </summary>
+        /// <param name="tuple">The tuple to convert</param>
+        public static implicit operator Vector3f((float X, float Y, float Z) tuple) => new Vector3f(tuple.X, tuple.Y, tuple.Z);
 
         /// <summary>X (horizontal) component of the vector</summary>
         public float X;


### PR DESCRIPTION
# Description

Fixes #267.

# How to test this PR?

```cs
Color color = (1, 2, 3, 4);
var (r, g, b, a) = color;

Vector2f vecf = (1.2f, 2.2f);
var (xf, yf) = vecf;

Vector2i veci = (1, 2);
var (xi, yi) = veci;

Vector2u vecu = (1, 2);
var (xu, yu) = vecu;

Vector3f vecf3 = (1.2f, 2.2f, 3.2f);
var (xf3, yf3, zf3) = vecf3;

IntRect recti = (1, 2, 3, 4);
var (li, ti, hi, wi) = recti;

FloatRect rectf = (1, 2, 3, 4);
var (lf, tf, hf, wf) = rectf;
```