### PR TITLE
Replace GCHandle.Alloc with fixed statements

### DIFF
--- a/src/SFML.Audio/Music.cs
+++ b/src/SFML.Audio/Music.cs
@@ -74,15 +74,14 @@ namespace SFML.Audio
         public Music(byte[] bytes) :
             base(IntPtr.Zero)
         {
-            var pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            try
+            unsafe
             {
-                CPointer = sfMusic_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
+                fixed (void* ptr = bytes)
+                {
+                    CPointer = sfMusic_createFromMemory((IntPtr)ptr, (UIntPtr)bytes.Length);
+                }
             }
-            finally
-            {
-                pin.Free();
-            }
+
             if (IsInvalid)
             {
                 throw new LoadingFailedException("music");

--- a/src/SFML.Audio/SoundBuffer.cs
+++ b/src/SFML.Audio/SoundBuffer.cs
@@ -72,15 +72,14 @@ namespace SFML.Audio
         public SoundBuffer(byte[] bytes) :
             base(IntPtr.Zero)
         {
-            var pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            try
+            unsafe
             {
-                CPointer = sfSoundBuffer_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
+                fixed (void* ptr = bytes)
+                {
+                    CPointer = sfSoundBuffer_createFromMemory((IntPtr)ptr, (UIntPtr)bytes.Length);
+                }
             }
-            finally
-            {
-                pin.Free();
-            }
+
             if (IsInvalid)
             {
                 throw new LoadingFailedException("sound buffer");

--- a/src/SFML.Graphics/Font.cs
+++ b/src/SFML.Graphics/Font.cs
@@ -62,15 +62,14 @@ namespace SFML.Graphics
         public Font(byte[] bytes) :
             base(IntPtr.Zero)
         {
-            var pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            try
+            unsafe
             {
-                CPointer = sfFont_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
+                fixed (void* ptr = bytes)
+                {
+                    CPointer = sfFont_createFromMemory((IntPtr)ptr, (UIntPtr)bytes.Length);
+                }
             }
-            finally
-            {
-                pin.Free();
-            }
+
             if (IsInvalid)
             {
                 throw new LoadingFailedException("font");

--- a/src/SFML.Graphics/Image.cs
+++ b/src/SFML.Graphics/Image.cs
@@ -87,15 +87,14 @@ namespace SFML.Graphics
         public Image(byte[] bytes) :
             base(IntPtr.Zero)
         {
-            var pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            try
+            unsafe
             {
-                CPointer = sfImage_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length);
+                fixed (void* ptr = bytes)
+                {
+                    CPointer = sfImage_createFromMemory((IntPtr)ptr, (UIntPtr)bytes.Length);
+                }
             }
-            finally
-            {
-                pin.Free();
-            }
+
             if (IsInvalid)
             {
                 throw new LoadingFailedException("image");

--- a/src/SFML.Graphics/Texture.cs
+++ b/src/SFML.Graphics/Texture.cs
@@ -205,21 +205,19 @@ namespace SFML.Graphics
         public Texture(byte[] bytes, IntRect area, bool srgb = false) :
             base(IntPtr.Zero)
         {
-            var pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            try
+            unsafe
             {
-                if (srgb)
+                fixed (void* ptr = bytes)
                 {
-                    CPointer = sfTexture_createSrgbFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length, ref area);
+                    if (srgb)
+                    {
+                        CPointer = sfTexture_createSrgbFromMemory((IntPtr)ptr, (UIntPtr)bytes.Length, ref area);
+                    }
+                    else
+                    {
+                        CPointer = sfTexture_createFromMemory((IntPtr)ptr, (UIntPtr)bytes.Length, ref area);
+                    }
                 }
-                else
-                {
-                    CPointer = sfTexture_createFromMemory(pin.AddrOfPinnedObject(), (UIntPtr)bytes.Length, ref area);
-                }
-            }
-            finally
-            {
-                pin.Free();
             }
 
             if (IsInvalid)


### PR DESCRIPTION
Replaces leftover uses of `GCHandle.Alloc(obj, GCHandleType.Pinned)` with fixed statements.