### PR TITLE
Use Span<T> for APIs

### DIFF
--- a/SFML.Module.props
+++ b/SFML.Module.props
@@ -21,4 +21,8 @@
     <PackageReference Include="CSFML" Version="[3.0.0-rc.1, 3.1)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.6.0" />
+  </ItemGroup>
+
 </Project>

--- a/examples/opengl/OpenGL.cs
+++ b/examples/opengl/OpenGL.cs
@@ -58,7 +58,7 @@ namespace opengl
             {
                 GL.GenTextures(1, out texture);
                 GL.BindTexture(TextureTarget.Texture2D, texture);
-                GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, (int)image.Size.X, (int)image.Size.Y, 0, PixelFormat.Rgba, PixelType.UnsignedByte, image.Pixels);
+                GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, (int)image.Size.X, (int)image.Size.Y, 0, PixelFormat.Rgba, PixelType.UnsignedByte, image.Pixels.ToArray());
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
             }

--- a/src/SFML.Audio/EffectProcessor.cs
+++ b/src/SFML.Audio/EffectProcessor.cs
@@ -84,8 +84,8 @@ namespace SFML.Audio
     /// occur.
     /// </summary>
     ////////////////////////////////////////////////////////////
-    public delegate long EffectProcessor(float[] inputFrames, float[] outputFrames, uint frameChannelCount);
+    public delegate long EffectProcessor(ReadOnlySpan<float> inputFrames, out uint inputFramesRead, Span<float> outputFrames, out uint outputFramesWritten, uint frameChannelCount);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate long EffectProcessorInternal(IntPtr inputFrames, uint inputFrameCount, IntPtr outputFrames, uint outputFrameCount, uint frameChannelCount);
+    internal unsafe delegate long EffectProcessorInternal(float* inputFrames, ref uint inputFrameCount, float* outputFrames, ref uint outputFrameCount, uint frameChannelCount);
 }

--- a/src/SFML.Audio/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/SFML.Audio/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 This file is used by the publish/package process of your project. You can customize the behavior of this process
 by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121. 
@@ -7,7 +7,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <PublishDir>bin\PublishOutput</PublishDir>
   </PropertyGroup>
 </Project>

--- a/src/SFML.Audio/SFML.Audio.csproj
+++ b/src/SFML.Audio/SFML.Audio.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <SFMLModule>Audio</SFMLModule>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>

--- a/src/SFML.Audio/SoundBufferRecorder.cs
+++ b/src/SFML.Audio/SoundBufferRecorder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SFML.Audio
@@ -59,9 +60,12 @@ namespace SFML.Audio
         /// <param name="samples">Array of samples to process</param>
         /// <returns>False to stop recording audio data, true to continue</returns>
         ////////////////////////////////////////////////////////////
-        protected override bool OnProcessSamples(short[] samples)
+        protected override bool OnProcessSamples(ReadOnlySpan<short> samples)
         {
-            _samplesArray.AddRange(samples);
+            for (var i = 0; i < samples.Length; i++)
+            {
+                _samplesArray.Add(samples[i]);
+            }
             return true;
         }
 

--- a/src/SFML.Graphics/Font.cs
+++ b/src/SFML.Graphics/Font.cs
@@ -39,7 +39,7 @@ namespace SFML.Graphics
         /// <param name="stream">Source stream to read from</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Font(Stream stream) : base(IntPtr.Zero)
+        public Font(Stream stream) : base(IntPtr.Zero)  // TODO this stream needs to stay alive
         {
             using (var adaptor = new StreamAdaptor(stream))
             {
@@ -59,7 +59,7 @@ namespace SFML.Graphics
         /// <param name="bytes">Byte array containing the file contents</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Font(byte[] bytes) :
+        public Font(byte[] bytes) : // TODO this memory needs to stay alive
             base(IntPtr.Zero)
         {
             unsafe

--- a/src/SFML.Graphics/IRenderTarget.cs
+++ b/src/SFML.Graphics/IRenderTarget.cs
@@ -1,3 +1,4 @@
+using System;
 using SFML.System;
 
 namespace SFML.Graphics
@@ -215,7 +216,7 @@ namespace SFML.Graphics
         /// <param name="vertices">Array of vertices to draw</param>
         /// <param name="type">Type of primitives to draw</param>
         ////////////////////////////////////////////////////////////
-        void Draw(Vertex[] vertices, PrimitiveType type);
+        void Draw(ReadOnlySpan<Vertex> vertices, PrimitiveType type);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -225,30 +226,7 @@ namespace SFML.Graphics
         /// <param name="type">Type of primitives to draw</param>
         /// <param name="states">Render states to use for drawing</param>
         ////////////////////////////////////////////////////////////
-        void Draw(Vertex[] vertices, PrimitiveType type, RenderStates states);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices, with default render states
-        /// </summary>
-        /// <param name="vertices">Array of vertices to draw</param>
-        /// <param name="start">Index of the first vertex to draw in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        ////////////////////////////////////////////////////////////
-        void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices
-        /// </summary>
-        /// <param name="vertices">Pointer to the vertices</param>
-        /// <param name="start">Index of the first vertex to use in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        /// <param name="states">Render states to use for drawing</param>
-        ////////////////////////////////////////////////////////////
-        void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type, RenderStates states);
+        void Draw(ReadOnlySpan<Vertex> vertices, PrimitiveType type, RenderStates states);
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.Graphics/RenderTexture.cs
+++ b/src/SFML.Graphics/RenderTexture.cs
@@ -322,40 +322,17 @@ namespace SFML.Graphics
         /// <param name="vertices">Pointer to the vertices</param>
         /// <param name="type">Type of primitives to draw</param>
         ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, PrimitiveType type) => Draw(vertices, type, RenderStates.Default);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by an array of vertices
-        /// </summary>
-        /// <param name="vertices">Pointer to the vertices</param>
-        /// <param name="type">Type of primitives to draw</param>
-        /// <param name="states">Render states to use for drawing</param>
-        ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, PrimitiveType type, RenderStates states) => Draw(vertices, 0, (uint)vertices.Length, type, states);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices, with default render states
-        /// </summary>
-        /// <param name="vertices">Array of vertices to draw</param>
-        /// <param name="start">Index of the first vertex to draw in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type) => Draw(vertices, start, count, type, RenderStates.Default);
+        public void Draw(ReadOnlySpan<Vertex> vertices, PrimitiveType type) => Draw(vertices, type, RenderStates.Default);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Draw primitives defined by a sub-array of vertices
         /// </summary>
         /// <param name="vertices">Pointer to the vertices</param>
-        /// <param name="start">Index of the first vertex to use in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
         /// <param name="type">Type of primitives to draw</param>
         /// <param name="states">Render states to use for drawing</param>
         ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type, RenderStates states)
+        public void Draw(ReadOnlySpan<Vertex> vertices, PrimitiveType type, RenderStates states)
         {
             var marshaledStates = states.Marshal();
 
@@ -363,7 +340,7 @@ namespace SFML.Graphics
             {
                 fixed (Vertex* vertexPtr = vertices)
                 {
-                    sfRenderTexture_drawPrimitives(CPointer, vertexPtr + start, (UIntPtr)count, type, ref marshaledStates);
+                    sfRenderTexture_drawPrimitives(CPointer, vertexPtr, (UIntPtr)vertices.Length, type, ref marshaledStates);
                 }
             }
         }

--- a/src/SFML.Graphics/RenderWindow.cs
+++ b/src/SFML.Graphics/RenderWindow.cs
@@ -170,7 +170,7 @@ namespace SFML.Graphics
         /// <param name="size">Icon's width and height, in pixels</param>
         /// <param name="pixels">Array of pixels, format must be RGBA 32 bits</param>
         ////////////////////////////////////////////////////////////
-        public override void SetIcon(Vector2u size, byte[] pixels)
+        public override void SetIcon(Vector2u size, ReadOnlySpan<byte> pixels)
         {
             unsafe
             {
@@ -498,40 +498,17 @@ namespace SFML.Graphics
         /// <param name="vertices">Pointer to the vertices</param>
         /// <param name="type">Type of primitives to draw</param>
         ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, PrimitiveType type) => Draw(vertices, type, RenderStates.Default);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by an array of vertices
-        /// </summary>
-        /// <param name="vertices">Pointer to the vertices</param>
-        /// <param name="type">Type of primitives to draw</param>
-        /// <param name="states">Render states to use for drawing</param>
-        ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, PrimitiveType type, RenderStates states) => Draw(vertices, 0, (uint)vertices.Length, type, states);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Draw primitives defined by a sub-array of vertices, with default render states
-        /// </summary>
-        /// <param name="vertices">Array of vertices to draw</param>
-        /// <param name="start">Index of the first vertex to draw in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
-        /// <param name="type">Type of primitives to draw</param>
-        ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type) => Draw(vertices, start, count, type, RenderStates.Default);
+        public void Draw(ReadOnlySpan<Vertex> vertices, PrimitiveType type) => Draw(vertices, type, RenderStates.Default);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
         /// Draw primitives defined by a sub-array of vertices
         /// </summary>
         /// <param name="vertices">Pointer to the vertices</param>
-        /// <param name="start">Index of the first vertex to use in the array</param>
-        /// <param name="count">Number of vertices to draw</param>
         /// <param name="type">Type of primitives to draw</param>
         /// <param name="states">Render states to use for drawing</param>
         ////////////////////////////////////////////////////////////
-        public void Draw(Vertex[] vertices, uint start, uint count, PrimitiveType type, RenderStates states)
+        public void Draw(ReadOnlySpan<Vertex> vertices, PrimitiveType type, RenderStates states)
         {
             var marshaledStates = states.Marshal();
 
@@ -539,7 +516,7 @@ namespace SFML.Graphics
             {
                 fixed (Vertex* vertexPtr = vertices)
                 {
-                    sfRenderWindow_drawPrimitives(CPointer, vertexPtr + start, (UIntPtr)count, type, ref marshaledStates);
+                    sfRenderWindow_drawPrimitives(CPointer, vertexPtr, (UIntPtr)vertices.Length, type, ref marshaledStates);
                 }
             }
         }

--- a/src/SFML.Graphics/SFML.Graphics.csproj
+++ b/src/SFML.Graphics/SFML.Graphics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <SFMLModule>Graphics</SFMLModule>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>

--- a/src/SFML.Graphics/Shader.cs
+++ b/src/SFML.Graphics/Shader.cs
@@ -351,7 +351,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>float</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, float[] array)
+        public unsafe void SetUniformArray(string name, ReadOnlySpan<float> array)
         {
             fixed (float* data = array)
             {
@@ -366,7 +366,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>vec2</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Vec2[] array)
+        public unsafe void SetUniformArray(string name, ReadOnlySpan<Glsl.Vec2> array)
         {
             fixed (Glsl.Vec2* data = array)
             {
@@ -381,7 +381,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>vec3</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Vec3[] array)
+        public unsafe void SetUniformArray(string name, ReadOnlySpan<Glsl.Vec3> array)
         {
             fixed (Glsl.Vec3* data = array)
             {
@@ -396,7 +396,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>vec4</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Vec4[] array)
+        public unsafe void SetUniformArray(string name, ReadOnlySpan<Glsl.Vec4> array)
         {
             fixed (Glsl.Vec4* data = array)
             {
@@ -411,7 +411,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>mat3</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Mat3[] array)
+        public unsafe void SetUniformArray(string name, ReadOnlySpan<Glsl.Mat3> array)
         {
             fixed (Glsl.Mat3* data = array)
             {
@@ -426,7 +426,7 @@ namespace SFML.Graphics
         /// <param name="name">Name of the uniform variable in GLSL</param>
         /// <param name="array">array of <c>mat4</c> values</param>
         ////////////////////////////////////////////////////////////
-        public unsafe void SetUniformArray(string name, Glsl.Mat4[] array)
+        public unsafe void SetUniformArray(string name, ReadOnlySpan<Glsl.Mat4> array)
         {
             fixed (Glsl.Mat4* data = array)
             {

--- a/src/SFML.Graphics/Text.cs
+++ b/src/SFML.Graphics/Text.cs
@@ -169,12 +169,11 @@ namespace SFML.Graphics
                     }
                 }
 
-                // Copy it to a byte array
-                var sourceBytes = new byte[length * 4];
-                Marshal.Copy(source, sourceBytes, 0, sourceBytes.Length);
-
                 // Convert it to a C# string
-                return Encoding.UTF32.GetString(sourceBytes);
+                unsafe
+                {
+                    return Encoding.UTF32.GetString((byte*)source, (int)(length * 4));
+                }
             }
 
             set

--- a/src/SFML.Graphics/Texture.cs
+++ b/src/SFML.Graphics/Texture.cs
@@ -186,7 +186,7 @@ namespace SFML.Graphics
         /// <param name="srgb">True to convert the texture source from sRGB, false otherwise</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Texture(byte[] bytes, bool srgb = false) :
+        public Texture(ReadOnlySpan<byte> bytes, bool srgb = false) :
             this(bytes, new IntRect((0, 0), (0, 0)), srgb)
         {
         }
@@ -200,7 +200,7 @@ namespace SFML.Graphics
         /// <param name="srgb">True to convert the texture source from sRGB, false otherwise</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Texture(byte[] bytes, IntRect area, bool srgb = false) :
+        public Texture(ReadOnlySpan<byte> bytes, IntRect area, bool srgb = false) :
             base(IntPtr.Zero)
         {
             unsafe
@@ -261,7 +261,7 @@ namespace SFML.Graphics
         /// </summary>
         /// <param name="pixels">Array of pixels to copy to the texture</param>
         ////////////////////////////////////////////////////////////
-        public void Update(byte[] pixels) => Update(pixels, Size, new Vector2u());
+        public void Update(ReadOnlySpan<byte> pixels) => Update(pixels, Size, new Vector2u());
 
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -271,7 +271,7 @@ namespace SFML.Graphics
         /// <param name="size">Width and height of the pixel region contained in pixels</param>
         /// <param name="dest">Coordinates of the destination position</param>
         ////////////////////////////////////////////////////////////
-        public void Update(byte[] pixels, Vector2u size, Vector2u dest)
+        public void Update(ReadOnlySpan<byte> pixels, Vector2u size, Vector2u dest)
         {
             unsafe
             {

--- a/src/SFML.Graphics/VertexBuffer.cs
+++ b/src/SFML.Graphics/VertexBuffer.cs
@@ -137,7 +137,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Update the <see cref="VertexBuffer"/> from a <see cref="Vertex"/>[]
+        /// Update the <see cref="VertexBuffer"/> from a ReadOnlySpan&lt;<see cref="Vertex"/>&gt;
         /// </summary>
         /// <remarks>
         /// <para>
@@ -172,7 +172,7 @@ namespace SFML.Graphics
         /// <param name="vertexCount">Number of vertices to copy</param>
         /// <param name="offset">Offset in the buffer to copy to</param>
         ////////////////////////////////////////////////////////////
-        public bool Update(Vertex[] vertices, uint vertexCount, uint offset)
+        public bool Update(ReadOnlySpan<Vertex> vertices, uint vertexCount, uint offset)
         {
             unsafe
             {
@@ -185,7 +185,7 @@ namespace SFML.Graphics
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Update a part of the buffer from a <see cref="Vertex"/>[]
+        /// Update a part of the buffer from a ReadOnlySpan&lt;<see cref="Vertex"/>&gt;
         /// </summary>
         /// <remarks>
         /// <para>
@@ -209,11 +209,11 @@ namespace SFML.Graphics
         /// </remarks>
         /// <param name="vertices">Array of vertices to copy to the buffer</param>
         ////////////////////////////////////////////////////////////
-        public bool Update(Vertex[] vertices) => Update(vertices, (uint)vertices.Length, 0);
+        public bool Update(ReadOnlySpan<Vertex> vertices) => Update(vertices, (uint)vertices.Length, 0);
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Update a part of the buffer from a <see cref="Vertex"/>[]
+        /// Update a part of the buffer from a ReadOnlySpan&lt;<see cref="Vertex"/>&gt;
         /// </summary>
         /// <remarks>
         /// <para>
@@ -247,7 +247,7 @@ namespace SFML.Graphics
         /// <param name="vertices">Array of vertices to copy to the buffer</param>
         /// <param name="offset">Offset in the buffer to copy to</param>
         ////////////////////////////////////////////////////////////
-        public bool Update(Vertex[] vertices, uint offset) => Update(vertices, (uint)vertices.Length, offset);
+        public bool Update(ReadOnlySpan<Vertex> vertices, uint offset) => Update(vertices, (uint)vertices.Length, offset);
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.Net/SFML.Net.csproj
+++ b/src/SFML.Net/SFML.Net.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\SFML.NuGet.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <PackageId>SFML.Net</PackageId>
     <Description>
       A simple, fast, cross-platform and object-oriented multimedia API. It provides access to windowing, graphics, audio and network.

--- a/src/SFML.System/Buffer.cs
+++ b/src/SFML.System/Buffer.cs
@@ -28,11 +28,11 @@ namespace SFML.System
 
         ////////////////////////////////////////////////////////////
         /// <summary>
-        /// Get a copy of the buffer data
+        /// Get the buffer data
         /// </summary>
-        /// <returns>A byte array containing the buffer data</returns>
+        /// <returns>A span containing the buffer data</returns>
         ////////////////////////////////////////////////////////////
-        public byte[] GetData()
+        public ReadOnlySpan<byte> GetData()
         {
             var size = sfBuffer_getSize(CPointer);
             var ptr = sfBuffer_getData(CPointer);
@@ -42,10 +42,10 @@ namespace SFML.System
                 return Array.Empty<byte>();
             }
 
-            var data = new byte[(int)size];
-            Marshal.Copy(ptr, data, 0, (int)size);
-
-            return data;
+            unsafe
+            {
+                return new ReadOnlySpan<byte>(ptr.ToPointer(), (int)size);
+            }
         }
 
         ////////////////////////////////////////////////////////////

--- a/src/SFML.System/SFML.System.csproj
+++ b/src/SFML.System/SFML.System.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <SFMLModule>System</SFMLModule>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>

--- a/src/SFML.Window/Clipboard.cs
+++ b/src/SFML.Window/Clipboard.cs
@@ -29,10 +29,11 @@ namespace SFML.Window
                     }
                 }
 
-                var sourceBytes = new byte[length * 4];
-                Marshal.Copy(source, sourceBytes, 0, sourceBytes.Length);
-
-                return Encoding.UTF32.GetString(sourceBytes);
+                // Convert it to a C# string
+                unsafe
+                {
+                    return Encoding.UTF32.GetString((byte*)source, (int)(length * 4));
+                }
             }
             set
             {

--- a/src/SFML.Window/Cursor.cs
+++ b/src/SFML.Window/Cursor.cs
@@ -215,7 +215,7 @@ namespace SFML.Window
         /// <param name="hotspot">(x,y) location of the hotspot</param>
         /// <exception cref="LoadingFailedException" />
         ////////////////////////////////////////////////////////////
-        public Cursor(byte[] pixels, Vector2u size, Vector2u hotspot)
+        public Cursor(ReadOnlySpan<byte> pixels, Vector2u size, Vector2u hotspot)
             : base((IntPtr)0)
         {
             unsafe

--- a/src/SFML.Window/SFML.Window.csproj
+++ b/src/SFML.Window/SFML.Window.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <SFMLModule>Window</SFMLModule>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>

--- a/src/SFML.Window/VideoMode.cs
+++ b/src/SFML.Window/VideoMode.cs
@@ -52,23 +52,25 @@ namespace SFML.Window
         /// Get the list of all the supported fullscreen video modes
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public static VideoMode[] FullscreenModes
+        public static ReadOnlySpan<VideoMode> FullscreenModes
         {
             get
             {
                 unsafe
                 {
                     var modesPtr = sfVideoMode_getFullscreenModes(out var count);
-                    var modes = new VideoMode[(int)count];
-                    for (var i = 0; i < (int)count; ++i)
+                    Array.Resize(ref _fullscreenModes, (int)count);
+
+                    for (var i = 0; i < _fullscreenModes.Length; i++)
                     {
-                        modes[i] = modesPtr[i];
+                        _fullscreenModes[i] = modesPtr[i];
                     }
 
-                    return modes;
+                    return _fullscreenModes;
                 }
             }
         }
+        private static VideoMode[] _fullscreenModes;
 
         ////////////////////////////////////////////////////////////
         /// <summary>

--- a/src/SFML.Window/Vulkan.cs
+++ b/src/SFML.Window/Vulkan.cs
@@ -40,21 +40,22 @@ namespace SFML.Window
         /// </summary>
         /// <returns>Vulkan instance extensions required for graphics</returns>
         ////////////////////////////////////////////////////////////
-        public static string[] GetGraphicsRequiredInstanceExtensions()
+        public static ReadOnlySpan<string> GetGraphicsRequiredInstanceExtensions()
         {
             unsafe
             {
                 var extensionsPtr = sfVulkan_getGraphicsRequiredInstanceExtensions(out var count);
-                var extensions = new string[(int)count];
+                Array.Resize(ref _vulkanExtensions, (int)count);
 
-                for (var i = 0; i < (int)count; ++i)
+                for (var i = 0; i < _vulkanExtensions.Length; i++)
                 {
-                    extensions[i] = Marshal.PtrToStringAnsi(extensionsPtr[i]);
+                    _vulkanExtensions[i] = Marshal.PtrToStringAnsi(extensionsPtr[i]);
                 }
 
-                return extensions;
+                return _vulkanExtensions;
             }
         }
+        private static string[] _vulkanExtensions;
 
         #region Imports
         [DllImport(CSFML.Window, CallingConvention = CallingConvention.Cdecl), SuppressUnmanagedCodeSecurity]

--- a/src/SFML.Window/Window.cs
+++ b/src/SFML.Window/Window.cs
@@ -169,7 +169,7 @@ namespace SFML.Window
         /// <param name="size">Icon's width and height, in pixels</param>
         /// <param name="pixels">Array of pixels, format must be RGBA 32 bits</param>
         ////////////////////////////////////////////////////////////
-        public override void SetIcon(Vector2u size, byte[] pixels)
+        public override void SetIcon(Vector2u size, ReadOnlySpan<byte> pixels)
         {
             unsafe
             {

--- a/src/SFML.Window/WindowBase.cs
+++ b/src/SFML.Window/WindowBase.cs
@@ -166,7 +166,7 @@ namespace SFML.Window
         /// <param name="size">Icon's width and height, in pixels</param>
         /// <param name="pixels">Array of pixels, format must be RGBA 32 bits</param>
         ////////////////////////////////////////////////////////////
-        public virtual void SetIcon(Vector2u size, byte[] pixels)
+        public virtual void SetIcon(Vector2u size, ReadOnlySpan<byte> pixels)
         {
             unsafe
             {


### PR DESCRIPTION
Supersedes #263.

To recap, what we want to do is:

- Multitarget .NET Standard 2.0 and .NET Standard 2.1, and install System.Memory on NS2.0 to gain access to Span<T> there
- Replace T[] with Span<T> in input parameters where possible - this is a trivial change that just allows slicing
- Replace T[] returns with Span<T> where possible (i.e. when we want to just give a view into memory) - this reduces the number of allocations and solves some anti-patterns like Image.Pixels
- Prefer ReadOnlySpan<T> over Span<T> where possible

In some cases, the implementation has to be split in NS2.0 and NS2.1 specific sections to be able to use Span-enhanced methods from .NET. One such example is in StreamAdaptor's Read method, where you can read directly into a Span<T> on NS2.1.

Things to consider:
- Spans must be used carefully with memory that can get invalidated from the C/C++ side, so we have to make sure that such memory will never be freed / moved for places where we just take the pointers and convert them to spans